### PR TITLE
add 2441V thermostat device for temperature weirdness

### DIFF
--- a/pyinsteon/commands.py
+++ b/pyinsteon/commands.py
@@ -288,6 +288,7 @@ commands.add(
 )
 commands.add(EXTENDED_GET_SET_2, 0x2E, 0x02, None)
 commands.add(THERMOSTAT_STATUS_RESPONSE, 0x2E, 0x02, {"d1": 0x01})
+commands.add(THERMOSTAT_STATUS_RESPONSE, 0x2E, 0x00, {"d2": 0x01})
 
 # cmd2 ne 0x00 => no confict w/ read aldb
 commands.add(OFF_AT_RAMP_RATE, 0x2F, None, False, True)

--- a/pyinsteon/device_types/__init__.py
+++ b/pyinsteon/device_types/__init__.py
@@ -1,8 +1,9 @@
 """Insteon device types."""
 
 from .climate_control import (
-    ClimateControl_Thermostat,
-    ClimateControl_WirelessThermostat,
+    ClimateControl_Thermostat_2441V,
+    ClimateControl_Thermostat_Generic,
+    ClimateControl_Thermostat_Wireless,
 )
 from .dimmable_lighting_control import (
     DimmableLightingControl,

--- a/pyinsteon/device_types/ipdb.py
+++ b/pyinsteon/device_types/ipdb.py
@@ -4,8 +4,9 @@ import logging
 
 from . import (
     PLM,
-    ClimateControl_Thermostat,
-    ClimateControl_WirelessThermostat,
+    ClimateControl_Thermostat_Generic,
+    ClimateControl_Thermostat_Wireless,
+    ClimateControl_Thermostat_2441V,
     DimmableLightingControl,
     DimmableLightingControl_DinRail,
     DimmableLightingControl_FanLinc,
@@ -1054,7 +1055,7 @@ class IPDB:
             0x00001F,
             "Thermostat Adapter",
             "2441V",
-            ClimateControl_Thermostat,
+            ClimateControl_Thermostat_2441V,
         ),
         Product(0x05, 0x04, 0x000024, "EZTherm", "", UnknownDevice),
         Product(
@@ -1066,9 +1067,9 @@ class IPDB:
             None,
             "Wireless Thermostat",
             "2441ZTH",
-            ClimateControl_WirelessThermostat,
+            ClimateControl_Thermostat_Wireless,
         ),
-        Product(0x05, 0x08, None, "Thermostat", "2441TH", ClimateControl_Thermostat),
+        Product(0x05, 0x08, None, "Thermostat", "2441TH", ClimateControl_Thermostat_Generic),
         Product(0x05, 0x09, 0x000094, "7 Day Thermostat", "4715", UnknownDevice),
         Product(
             0x05,
@@ -1076,9 +1077,9 @@ class IPDB:
             None,
             "Wireless Thermostat",
             "2441ZTH",
-            ClimateControl_WirelessThermostat,
+            ClimateControl_Thermostat_Wireless,
         ),
-        Product(0x05, 0x0B, None, "Thermostat", "2441TH", ClimateControl_Thermostat),
+        Product(0x05, 0x0B, None, "Thermostat", "2441TH", ClimateControl_Thermostat_Generic),
         Product(
             0x05,
             0x0E,
@@ -1087,15 +1088,15 @@ class IPDB:
             "2491T1E",
             UnknownDevice,
         ),
-        Product(0x05, 0x0F, None, "Thermostat", "2732-422", ClimateControl_Thermostat),
-        Product(0x05, 0x10, None, "Thermostat", "2732-522", ClimateControl_Thermostat),
+        Product(0x05, 0x0F, None, "Thermostat", "2732-422", ClimateControl_Thermostat_Generic),
+        Product(0x05, 0x10, None, "Thermostat", "2732-522", ClimateControl_Thermostat_Generic),
         Product(
             0x05,
             0x11,
             None,
             "Wireless Thermostat",
             "2732-432",
-            ClimateControl_WirelessThermostat,
+            ClimateControl_Thermostat_Wireless,
         ),
         Product(
             0x05,
@@ -1103,7 +1104,7 @@ class IPDB:
             None,
             "Wireless Thermostat",
             "2732-532",
-            ClimateControl_WirelessThermostat,
+            ClimateControl_Thermostat_Wireless,
         ),
         Product(
             0x05,
@@ -1111,7 +1112,7 @@ class IPDB:
             None,
             "Thermostat Heat Pump",
             "2732-232",
-            ClimateControl_Thermostat,
+            ClimateControl_Thermostat_Generic,
         ),
         Product(
             0x05,
@@ -1119,7 +1120,7 @@ class IPDB:
             None,
             "Thermostat Heat Pump",
             "2732-432",
-            ClimateControl_Thermostat,
+            ClimateControl_Thermostat_Generic,
         ),
         Product(
             0x05,
@@ -1127,10 +1128,10 @@ class IPDB:
             None,
             "Thermostat Heat Pump",
             "2732-532",
-            ClimateControl_Thermostat,
+            ClimateControl_Thermostat_Generic,
         ),
         Product(
-            0x05, 0x16, None, "Insteon Thermostat", "2441TH", ClimateControl_Thermostat
+            0x05, 0x16, None, "Insteon Thermostat", "2441TH", ClimateControl_Thermostat_Generic
         ),
         Product(
             0x05,
@@ -1138,7 +1139,7 @@ class IPDB:
             None,
             "Insteon Thermostat",
             "2732-422",
-            ClimateControl_Thermostat,
+            ClimateControl_Thermostat_Generic,
         ),
         Product(
             0x05,
@@ -1146,7 +1147,7 @@ class IPDB:
             None,
             "Insteon Thermostat",
             "2732-522",
-            ClimateControl_Thermostat,
+            ClimateControl_Thermostat_Generic,
         ),
         Product(0x06, None, None, "Generic Pool Controller", "", UnknownDevice),
         Product(0x06, 0x00, 0x000003, "EZPool", "", UnknownDevice),

--- a/pyinsteon/handlers/from_device/thermostat_status_response.py
+++ b/pyinsteon/handlers/from_device/thermostat_status_response.py
@@ -16,6 +16,18 @@ SYS_MODE_MAP = {
     3: ThermostatMode.COOL,
 }
 
+MODE_MAP_2441V = {
+    0: ThermostatMode.OFF,
+    1: ThermostatMode.HEAT,
+    2: ThermostatMode.COOL,
+    3: ThermostatMode.AUTO,
+}
+
+FAN_MAP_2441V = {
+    0: ThermostatMode.FAN_AUTO,
+    16: ThermostatMode.FAN_ALWAYS_ON,
+}
+
 
 def _parse_status_flag(status_flag):
     """Parse the status flag."""
@@ -72,4 +84,37 @@ class ThermostatStatusResponseHandler(InboundHandlerBase):
             heating=heating,
             celsius=celsius,
             heat_set_point=heat_set_point,
+        )
+
+
+class ThermostatStatusResponseHandler2441V(InboundHandlerBase):
+    """Thermostat Status Response Handler."""
+
+    def __init__(self, address):
+        """Init the ThermostatStatusResponseHandler class."""
+        super(ThermostatStatusResponseHandler2441V).__init__(
+            topic=THERMOSTAT_STATUS_RESPONSE,
+            address=address,
+            message_type=MessageFlagType.DIRECT,
+        )
+
+    @inbound_handler
+    def handle_response(self, cmd1, cmd2, target, user_data, hops_left):
+        """Handle the Status Response from a Thermostat."""
+        system_mode = MODE_MAP_2441V.get(user_data["d3"])
+        humidity = user_data["d4"]
+        temperature = user_data["d5"] / 2
+        cool_set_point = user_data["d6"]
+        heat_set_point = user_data["d7"]
+        fan_mode = FAN_MAP_2441V.get(user_data["d9"])
+        self._call_subscribers(
+            humidity=humidity,
+            temperature=temperature,
+            cool_set_point=cool_set_point,
+            heat_set_point=heat_set_point,
+            fan_mode=fan_mode,
+            system_mode=system_mode,
+            heating=False,
+            celsius=False,
+            cooling=False,
         )

--- a/pyinsteon/handlers/from_device/thermostat_temperature.py
+++ b/pyinsteon/handlers/from_device/thermostat_temperature.py
@@ -10,7 +10,7 @@ from ..inbound_base import InboundHandlerBase
 _LOGGER = logging.getLogger(__name__)
 
 
-class ThermostatTemperatureHandler(InboundHandlerBase):
+class ThermostatTemperatureHandlerBase(InboundHandlerBase):
     """Heat set point command inbound."""
 
     def __init__(self, address):
@@ -26,7 +26,30 @@ class ThermostatTemperatureHandler(InboundHandlerBase):
             message_type=MessageFlagType.DIRECT,
         )
 
+
+class ThermostatTemperatureHandlerGeneric(InboundHandlerBase):
+    """Heat set point command inbound."""
+
+    def __init__(self, address):
+        """Init the ThermostatTemperatureHandler class."""
+
+        super(ThermostatTemperatureHandlerGeneric).__init__(address=address)
+
     @inbound_handler
     def handle_response(self, cmd1, cmd2, target, user_data, hops_left):
         """Handle the Temperature response from a device."""
         self._call_subscribers(degrees=int(round(cmd2 / 2, 0)))
+
+
+class ThermostatTemperatureHandler2441V(InboundHandlerBase):
+    """Heat set point command inbound."""
+
+    def __init__(self, address):
+        """Init the ThermostatTemperatureHandler class."""
+
+        super(ThermostatTemperatureHandler2441V).__init__(address=address)
+
+    @inbound_handler
+    def handle_response(self, cmd1, cmd2, target, user_data, hops_left):
+        """Handle the Temperature response from a device."""
+        self._call_subscribers(degrees=int(cmd2))

--- a/pyinsteon/handlers/to_device/thermostat_heat_set_point.py
+++ b/pyinsteon/handlers/to_device/thermostat_heat_set_point.py
@@ -7,9 +7,10 @@ from .direct_command import DirectCommandHandlerBase
 class ThermostatHeatSetPointCommand(DirectCommandHandlerBase):
     """Manage an outbound THERMOSTAT_SET_COOL_SETPOINT command to a device."""
 
-    def __init__(self, address):
+    def __init__(self, address, multiplier=0.5):
         """Init the ThermostatHeatSetPointCommand class."""
         super().__init__(topic=THERMOSTAT_SET_HEAT_SETPOINT, address=address)
+        self.multiplier = multiplier
 
     # pylint: disable=arguments-differ
     def send(self, degrees):
@@ -24,5 +25,5 @@ class ThermostatHeatSetPointCommand(DirectCommandHandlerBase):
     @direct_ack_handler
     def handle_direct_ack(self, cmd1, cmd2, target, user_data, hops_left):
         """Handle the OFF response direct ACK."""
-        self._call_subscribers(degrees=cmd2 * 0.5)
+        self._call_subscribers(degrees=cmd2 * self.multiplier)
         super().handle_direct_ack(cmd1, cmd2, target, user_data, hops_left)


### PR DESCRIPTION
Resolves #64 

This PR resolves the issue I am having where the `2441V` thermostat is returning the actual temperature in `cmd2` instead of needing to divide by 2.

```
2021-01-06 01:55:12,120 DEBUG pyinsteon.messages RX: msg_id: 0x50, address: 14f855, target: 34788c, flags: 0x0f, cmd1: 0x6e, cmd2: 0x3d
2021-01-06 01:55:12,120 INFO samples Topic: 14f855.thermostat_temperature_status.direct data: {'cmd1': 110, 'cmd2': 61, 'target': 34788c, 'user_data': None, 'hops_left': 3}
2021-01-06 01:55:12,120 INFO samples Topic: handler.14f855.thermostat_temperature_status.direct data: {'degrees': 61}
2021-01-06 01:55:12,121 INFO samples Topic: state_14f855_temperature_10 data: {'name': 'temperature', 'address': '14f855', 'value': 61.0, 'group': 10}
```

I added the device name to the classes I added because I wasn't sure what else to call it other than "`_why_oh_why_venstar`" which also didn't seem like a good name.  