### PR TITLE
Stop reading empty ALDB (#85)

### DIFF
--- a/pyinsteon/aldb/__init__.py
+++ b/pyinsteon/aldb/__init__.py
@@ -108,7 +108,7 @@ class ALDB(ALDBBase):
                 has_last = True
             if last_addr != 0x0000:
                 has_all = (last_addr - mem_addr) == 8
-            if len(self._records) == 1 and has_last:
+            if len(self._records) == 1 and has_last and has_first:
                 # Empty ALDB; yes it is possible with some devices like motion
                 has_all = True
             last_addr = mem_addr

--- a/pyinsteon/aldb/__init__.py
+++ b/pyinsteon/aldb/__init__.py
@@ -109,7 +109,7 @@ class ALDB(ALDBBase):
             if last_addr != 0x0000:
                 has_all = (last_addr - mem_addr) == 8
             if len(self._records) == 1 and has_last:
-                #Empty ALDB; yes it is possible with some devices like motion
+                # Empty ALDB; yes it is possible with some devices like motion
                 has_all = True
             last_addr = mem_addr
         _LOGGER.debug("Has First is %s", has_first)

--- a/pyinsteon/aldb/__init__.py
+++ b/pyinsteon/aldb/__init__.py
@@ -98,15 +98,19 @@ class ALDB(ALDBBase):
         has_all = False
         last_addr = 0x0000
         first = True
+        _LOGGER.debug("Checking ALDB load status: %s", self._address.id)
         for mem_addr in sorted(self._records, reverse=True):
             if first:
-                _LOGGER.debug("First Addr: 0x%4x", mem_addr)
+                _LOGGER.debug("First Addr: 0x%04x", mem_addr)
             if mem_addr == self._mem_addr:
                 has_first = True
             if self._records[mem_addr].is_high_water_mark:
                 has_last = True
             if last_addr != 0x0000:
                 has_all = (last_addr - mem_addr) == 8
+            if len(self._records) == 1 and has_last:
+                #Empty ALDB; yes it is possible with some devices like motion
+                has_all = True
             last_addr = mem_addr
         _LOGGER.debug("Has First is %s", has_first)
         _LOGGER.debug("Has Last is %s", has_last)

--- a/pyinsteon/aldb/aldb_base.py
+++ b/pyinsteon/aldb/aldb_base.py
@@ -67,7 +67,7 @@ class ALDBBase(ABC):
 
     @property
     def address(self) -> Address:
-        """Returnt the status of the device."""
+        """Return the address of the device."""
         return self._address
 
     @property


### PR DESCRIPTION
If a device has an empty ALDB it will return one record with both
high water and unused flags.  Technically a device should return NAK
because the PLM is not in the ALDB but a 2842-222 did respond with a
0x51.  In this case _calc_load_status will never set has_all and
will never return true.

Resolves pyinsteon/pyinsteon#85