### PR TITLE
Fix X10 All Lights On/Off and All Units Off commands

### DIFF
--- a/pyinsteon/tools/commands.py
+++ b/pyinsteon/tools/commands.py
@@ -3,7 +3,13 @@
 import inspect
 from types import MethodType
 
-from .. import devices
+from .. import (
+    async_x10_all_lights_off,
+    async_x10_all_lights_on,
+    async_x10_all_units_off,
+    devices,
+)
+from ..constants import HC_LOOKUP
 from ..managers.scene_manager import async_trigger_scene_off, async_trigger_scene_on
 from .tools_base import ToolsBase
 
@@ -197,6 +203,57 @@ class ToolsCommands(ToolsBase):
         else:
             result = func(**kwargs)
         self._log_stdout(f"Result: {str(result)}")
+
+    async def do_x10_all_lights_on(
+        self, housecode: str, log_stdout=None, background=False
+    ):
+        """Run the X10 All Lights On command.
+
+        Usage:
+          x10_all_lights_on housecode
+        """
+        housecode = await self._ensure_string(
+            str(housecode).lower(),
+            list(HC_LOOKUP.keys()),
+            "Housecode",
+            True,
+            log_stdout,
+        )
+        await async_x10_all_lights_on(housecode=housecode)
+
+    async def do_x10_all_lights_off(
+        self, housecode: str, log_stdout=None, background=False
+    ):
+        """Run the X10 All Lights Off command.
+
+        Usage:
+          x10_all_lights_off housecode
+        """
+        housecode = await self._ensure_string(
+            str(housecode).lower(),
+            list(HC_LOOKUP.keys()),
+            "Housecode",
+            True,
+            log_stdout,
+        )
+        await async_x10_all_lights_off(housecode=housecode)
+
+    async def do_x10_all_units_off(
+        self, housecode: str, log_stdout=None, background=False
+    ):
+        """Run the X10 All Units Off command.
+
+        Usage:
+          x10_all_units_off housecode
+        """
+        housecode = await self._ensure_string(
+            str(housecode).lower(),
+            list(HC_LOOKUP.keys()),
+            "Housecode",
+            True,
+            log_stdout,
+        )
+        await async_x10_all_units_off(housecode=housecode)
 
     # pylint: disable=arguments-renamed
     # pylint: disable=invalid-overridden-method

--- a/pyinsteon/tools/tools_base.py
+++ b/pyinsteon/tools/tools_base.py
@@ -18,6 +18,7 @@ from typing import List
 from .. import devices
 from ..address import Address
 from ..constants import RelayMode, ThermostatMode, ToggleMode
+from ..x10_address import X10Address
 from .log_filter import NoStdoutFilter, StdoutFilter, StripPrefixFilter
 from .utils import patch_stdin_stdout, set_loop, stdio
 
@@ -66,7 +67,10 @@ def validate_address(address, allow_all, match_device, log_stdout) -> List[Addre
         raise ValueError("No address provided")
 
     if address != "all":
-        address = Address(address)
+        try:
+            address = Address(address)
+        except ValueError:
+            address = X10Address(address)
         if not match_device or address in devices:
             return [address]
         log_stdout(f"No device found with address {address}")

--- a/pyinsteon/x10_address.py
+++ b/pyinsteon/x10_address.py
@@ -53,8 +53,10 @@ def create(housecode: str, unitcode: int):
 
     # 20, 21 and 22 for All Units Off, All Lights On and All Lights Off
     # 'fake' units
-    if unitcode in range(1, 17) or unitcode in range(20, 23):
+    if unitcode in range(1, 17):
         byte_unitcode = unitcode_to_byte(unitcode)
+    elif unitcode == 0:
+        byte_unitcode = 0x00
     else:
         if isinstance(unitcode, int):
             str_error = f"X10 unit code error: {unitcode}"

--- a/tests/test_tools/test_commands.py
+++ b/tests/test_tools/test_commands.py
@@ -350,7 +350,7 @@ class TestToolsCommandsMenu(ToolsTestBase):
                     await cmd_mgr.async_cmdloop("")
                     buffer = clean_buffer(stdout.buffer)
                     assert buffer[1] == 'Documented commands (type help <topic>):\n'
-                    assert len(buffer) == 6
+                    assert len(buffer) == 8
 
                     # Test help on the cmd command
                     cmd_mgr, _, stdout = self.setup_cmd_tool(

--- a/tests/test_x10_address.py
+++ b/tests/test_x10_address.py
@@ -65,6 +65,11 @@ class TestX10Address(unittest.TestCase):
         addr = X10Address("X10.A.02")
         assert bytes(addr) == b"n"
 
+    def test_for_all_units_lights_on_off(self):
+        """Test creating an X10 address for use in the All Lights and All Units on off commands."""
+        addr = create("a", 0)
+        assert isinstance(addr, X10Address)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #201 

- Enable X10 in tools
- Allow X10 address to accept zero as a valid unitcode