### PR TITLE
Fix read/write issues with ALDB

### DIFF
--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -45,6 +45,18 @@ class ALDB(ALDBBase):
             mode = ReadWriteMode.STANDARD
         else:
             mode = self._read_write_mode
+
+        if self._mem_addr not in self._records:
+            # Query the first record
+            try:
+                async for rec in self._read_manager.async_read(
+                    mem_addr=0, num_recs=1, read_write_mode=mode
+                ):
+                    self._mem_addr = rec.mem_addr
+                    self._add_record(rec)
+            finally:
+                await self._read_manager.async_stop()
+
         try:
             async for rec in self._read_manager.async_read(
                 mem_addr=mem_addr,

--- a/pyinsteon/aldb/aldb_base.py
+++ b/pyinsteon/aldb/aldb_base.py
@@ -320,7 +320,7 @@ class ALDBBase(ABC):
 
             if result == ResponseStatus.DIRECT_NAK_PRE_NAK and self._read_manager:
                 async for test_rec in self._read_manager.async_read(
-                    rec_to_write.mem_addr, 1, force=True
+                    rec_to_write.mem_addr, 1
                 ):
                     if rec_to_write.is_exact_match(test_rec):
                         result = ResponseStatus.SUCCESS

--- a/pyinsteon/managers/aldb_read_manager.py
+++ b/pyinsteon/managers/aldb_read_manager.py
@@ -111,7 +111,11 @@ class ALDBReadManager:
             try:
                 async with async_timeout.timeout(TIMER_RECORD):
                     record = await self._record_queue.get()
-                    if record is not None and record.mem_addr == mem_addr:
+                    if (
+                        record is not None
+                        and record.mem_addr == mem_addr
+                        or mem_addr == 0x0000
+                    ):
                         _LOGGER.debug("_read_one returning record: %s", str(record))
                         return record
                     _LOGGER.debug("_read_one not returning record: %s", str(record))


### PR DESCRIPTION
Fix ALDB issues with:

- Devices that respond with a "DIRECT ACK" on writing a record
- Reading a single record when the memory address requested is 0x0000 (i.e. first record)
- Force reading of the first record as a single record for devices where the memory address of the first record is not accurate