### PR TITLE
Fix issues with ALDB read/write

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "pyinsteon"
-version     = "1.3.4"
+version     = "1.3.5"
 license     = {text = "MIT License"}
 description = "Open-source Insteon home automation module running on Python 3."
 readme      = "DESCRIPTION.rst"


### PR DESCRIPTION
Fix ALDB issues with:

- Devices that respond with a "DIRECT ACK" on writing a record
- Reading a single record when the memory address requested is 0x0000 (i.e. first record)
- Force reading of the first record as a single record for devices where the memory address of the first record is not accurate1