### PR TITLE
I3 properties and extended messages

### DIFF
--- a/pyinsteon/commands.py
+++ b/pyinsteon/commands.py
@@ -20,6 +20,7 @@ from .topics import (
     EXTENDED_READ_WRITE_ALDB,
     EXTENDED_RECEIVED,
     EXTENDED_TRIGGER_ALL_LINK,
+    FACTORY_RESET,
     FX_USERNAME,
     GET_INSTEON_ENGINE_VERSION,
     GET_OPERATING_FLAGS,
@@ -646,6 +647,15 @@ commands.add(
     cmd1=0x30,
     cmd2=None,
     ud_allowed=False,
+    ud_required=False,
+    userdata=None,
+    use_group=False,
+)
+commands.add(
+    topic=FACTORY_RESET,
+    cmd1=0x34,
+    cmd2=0x00,
+    ud_allowed=True,
     ud_required=False,
     userdata=None,
     use_group=False,

--- a/pyinsteon/config/__init__.py
+++ b/pyinsteon/config/__init__.py
@@ -134,7 +134,6 @@ RADIO_BUTTON_GROUPS = "radio_button_groups"
 RAMP_RATE_IN_SEC = "ramp_rate_in_seconds"
 RELAY_MODE = "relay_mode"
 TOGGLE_BUTTON = "toggle_button"
-OPS_FLAGS_PROPERTY = "ops_flags_property"
 
 # Modem properties
 MODEM_CONFIG = "modem_config"

--- a/pyinsteon/device_types/dimmable_lighting_control.py
+++ b/pyinsteon/device_types/dimmable_lighting_control.py
@@ -830,8 +830,6 @@ class DimmableLightingControl_Dial(I3VariableResponderBase):
                 self._handlers[group]["manual_change"] = ManualChangeInbound(
                     self._address, group
                 )
-        self._register_default_ext_prop_read_managers()
-        self._register_default_ext_prop_write_managers()
 
     def _subscribe_to_handelers_and_managers(self):
         """Subscribe methods to handlers and managers."""

--- a/pyinsteon/device_types/i3_base.py
+++ b/pyinsteon/device_types/i3_base.py
@@ -80,8 +80,8 @@ def _default_ops_flags(dimmable: bool) -> List[OpsFlagDef]:
         # Group 5
         OpsFlagDef(TEND_ON, 5, 0, None, None, PropertyType.HIDDEN),
         # -- Night mode is set with (cmd1: 0x3B  cmd2: 0xXX) and (cmd2: 0x3C  cmd2: 0xXX)
-        OpsFlagDef(NIGHT_MODE_ON, 5, 1, None, None, PropertyType.HIDDEN),
-        OpsFlagDef(LED_BLINK_ON_ERROR_ON, 5, 2, None, None, PropertyType.ADVANCED),
+        OpsFlagDef(NIGHT_MODE_ON, 5, 1, None, None, PropertyType.STANDARD),
+        OpsFlagDef(LED_BLINK_ON_ERROR_ON, 5, 2, None, None, PropertyType.STANDARD),
         OpsFlagDef(CLEANUP_REPORT_OFF, 5, 3, None, None, PropertyType.HIDDEN),
         OpsFlagDef(DISABLE_BUTTONS, 5, 4, None, None, PropertyType.HIDDEN),
         # -- DETACH_LOAD_ON: future feature set/unset with 0x12, 0x13
@@ -103,15 +103,15 @@ def _default_ext_props(dimmable=True) -> List[ExtProp]:
     """Return a list of default extended properties for i3 devices."""
     show_dim = PropertyType.STANDARD if dimmable else PropertyType.HIDDEN
     return [
-        ExtProp(NIGHT_MODE_LED_BRIGHTNESS, int, False, PropertyType.HIDDEN),
-        ExtProp(NIGHT_MODE_RAMP_RATE, int, False, PropertyType.HIDDEN),
+        ExtProp(NIGHT_MODE_LED_BRIGHTNESS, int, False, PropertyType.STANDARD),
+        ExtProp(NIGHT_MODE_RAMP_RATE, int, False, PropertyType.STANDARD),
         ExtProp(RAMP_RATE, int, False, show_dim),
         ExtProp(ON_LEVEL, int, False, show_dim),
         ExtProp(LED_BRIGHTNESS, int, False, PropertyType.STANDARD),
         ExtProp(BRIGHTNESS_MIN, int, False, show_dim),
         ExtProp(BRIGHTNESS_MAX, int, False, show_dim),
         ExtProp(BRIGHTNESS_START, int, False, show_dim),
-        ExtProp(NIGHT_MODE_MAX_LEVEL, int, False, PropertyType.HIDDEN),
+        ExtProp(NIGHT_MODE_MAX_LEVEL, int, False, PropertyType.STANDARD),
     ]
 
 

--- a/pyinsteon/device_types/i3_base.py
+++ b/pyinsteon/device_types/i3_base.py
@@ -102,10 +102,11 @@ def _default_ops_flags(dimmable: bool) -> List[OpsFlagDef]:
 def _default_ext_props(dimmable=True) -> List[ExtProp]:
     """Return a list of default extended properties for i3 devices."""
     show_dim = PropertyType.STANDARD if dimmable else PropertyType.HIDDEN
+    show_dim_adv = PropertyType.ADVANCED if dimmable else PropertyType.HIDDEN
     return [
         ExtProp(NIGHT_MODE_LED_BRIGHTNESS, int, False, PropertyType.STANDARD),
         ExtProp(NIGHT_MODE_RAMP_RATE, int, False, PropertyType.STANDARD),
-        ExtProp(RAMP_RATE, int, False, show_dim),
+        ExtProp(RAMP_RATE, int, False, show_dim_adv),
         ExtProp(ON_LEVEL, int, False, show_dim),
         ExtProp(LED_BRIGHTNESS, int, False, PropertyType.STANDARD),
         ExtProp(BRIGHTNESS_MIN, int, False, show_dim),

--- a/pyinsteon/device_types/i3_base.py
+++ b/pyinsteon/device_types/i3_base.py
@@ -1,7 +1,7 @@
 """I3 device base classes."""
 import asyncio
 from collections import namedtuple
-from typing import Dict, List
+from typing import Dict, List, Union
 
 from ..config import (
     ACK_A_SCENE,
@@ -12,6 +12,7 @@ from ..config import (
     CLEANUP_REPORT_OFF,
     DETACH_LOAD_ON,
     DISABLE_BUTTONS,
+    DO_NOT_ROTATE_TO_OFF,
     GREEN_LED_OFF,
     INSTEON_OFF,
     KEY_BEEP_ON,
@@ -21,15 +22,13 @@ from ..config import (
     LED_OFF,
     LOAD_SENSE_2_ON,
     LOAD_SENSE_ON,
-    MOD_SYNC_SYNC,
-    NIGHT_LEDS_ON,
     NIGHT_MODE_LED_BRIGHTNESS,
     NIGHT_MODE_MAX_LEVEL,
     NIGHT_MODE_ON,
     NIGHT_MODE_RAMP_RATE,
     NO_CACHE,
     ON_LEVEL,
-    OPS_FLAGS_PROPERTY,
+    OPERATING_FLAGS,
     PROGRAM_LOCK_ON,
     RAMP_RATE,
     RED_LED_OFF,
@@ -43,8 +42,8 @@ from ..config import (
 )
 from ..config.extended_property import ExtendedProperty
 from ..config.op_flag_property_byte import OpFlagPropertyByte
-from ..config.operating_flag import OperatingFlag
 from ..constants import PropertyType, ResponseStatus
+from ..handlers.to_device.factory_reset import FactoryResetCommand
 from ..handlers.to_device.night_mode_off import NightModeOffCommand
 from ..handlers.to_device.night_mode_on import NightModeOnCommand
 from ..managers.ext_prop_read_manager import ExtendedPropertyReadManager
@@ -53,9 +52,9 @@ from ..utils import multiple_status
 from .on_off_responder_base import OnOffResponderBase
 from .variable_responder_base import VariableResponderBase
 
-OP_FLAG_PROP_1 = f"{OPS_FLAGS_PROPERTY}_1"
-OP_FLAG_PROP_2 = f"{OPS_FLAGS_PROPERTY}_2"
-OP_FLAG_PROP_3 = f"{OPS_FLAGS_PROPERTY}_3"
+OP_FLAG_1F_00 = f"{OPERATING_FLAGS}_1f_00"
+OP_FLAG_1F_05 = f"{OPERATING_FLAGS}_1f_05"
+OP_FLAG_1F_07 = f"{OPERATING_FLAGS}_1f_07"
 
 READ_MGRS = "ext_prop_read_mgrs"
 WRITE_MGRS = "ext_prop_write_mgrs"
@@ -69,6 +68,7 @@ ExtProp = namedtuple("ExtProp", ["name", "value_type", "is_read_only", "prop_typ
 
 def _default_ops_flags(dimmable: bool) -> List[OpsFlagDef]:
     """Return a list of default operating flags for i3 devices."""
+    show = PropertyType.STANDARD if dimmable else PropertyType.HIDDEN
     return [
         # Group 0
         OpsFlagDef(PROGRAM_LOCK_ON, 0, 0, 0x00, 0x01, PropertyType.STANDARD),
@@ -87,7 +87,7 @@ def _default_ops_flags(dimmable: bool) -> List[OpsFlagDef]:
         # -- DETACH_LOAD_ON: future feature set/unset with 0x12, 0x13
         OpsFlagDef(DETACH_LOAD_ON, 5, 5, 0x12, 0x13, PropertyType.HIDDEN),
         OpsFlagDef(ACK_A_SCENE, 5, 6, 0x1C, 0x1D, PropertyType.HIDDEN),
-        OpsFlagDef(RELAY_MODE_OFF, 5, 7, 0x1E, 0x1F, PropertyType.HIDDEN),
+        OpsFlagDef(RELAY_MODE_OFF, 5, 7, 0x1EC, 0x1F, show),
         # Group 7
         OpsFlagDef(YAKETY_YAK, 7, 0, None, None, PropertyType.HIDDEN),
         OpsFlagDef(RED_LED_OFF, 7, 1, 0x28, 0x29, PropertyType.STANDARD),
@@ -95,24 +95,42 @@ def _default_ops_flags(dimmable: bool) -> List[OpsFlagDef]:
         OpsFlagDef(GREEN_LED_OFF, 7, 3, 0x2C, 0x0D, PropertyType.STANDARD),
         OpsFlagDef(BLUE_LED_OFF, 7, 4, 0x2E, 0x2F, PropertyType.STANDARD),
         OpsFlagDef(NO_CACHE, 7, 5, 0x30, 0x31, PropertyType.HIDDEN),
+        OpsFlagDef(DO_NOT_ROTATE_TO_OFF, 7, 6, 0x32, 0x33, show),
     ]
 
 
 def _default_ext_props(dimmable=True) -> List[ExtProp]:
     """Return a list of default extended properties for i3 devices."""
     show_dim = PropertyType.STANDARD if dimmable else PropertyType.HIDDEN
-    show_dim_adv = PropertyType.ADVANCED if dimmable else PropertyType.HIDDEN
     return [
         ExtProp(NIGHT_MODE_LED_BRIGHTNESS, int, False, PropertyType.HIDDEN),
         ExtProp(NIGHT_MODE_RAMP_RATE, int, False, PropertyType.HIDDEN),
-        ExtProp(RAMP_RATE, int, False, show_dim_adv),
+        ExtProp(RAMP_RATE, int, False, show_dim),
         ExtProp(ON_LEVEL, int, False, show_dim),
         ExtProp(LED_BRIGHTNESS, int, False, PropertyType.STANDARD),
-        ExtProp(BRIGHTNESS_MIN, int, False, PropertyType.HIDDEN),
-        ExtProp(BRIGHTNESS_MAX, int, False, PropertyType.HIDDEN),
-        ExtProp(BRIGHTNESS_START, int, False, PropertyType.HIDDEN),
+        ExtProp(BRIGHTNESS_MIN, int, False, show_dim),
+        ExtProp(BRIGHTNESS_MAX, int, False, show_dim),
+        ExtProp(BRIGHTNESS_START, int, False, show_dim),
         ExtProp(NIGHT_MODE_MAX_LEVEL, int, False, PropertyType.HIDDEN),
     ]
+
+
+def _group_1_properties(properties: Dict[str, ExtendedProperty]):
+    """Return a set of properties that represent the 2E 01 properties."""
+    return {
+        2: properties[OP_FLAG_1F_00],
+        3: properties[OP_FLAG_1F_05],
+        4: properties[OP_FLAG_1F_07],
+        5: properties[RAMP_RATE],
+        6: properties[ON_LEVEL],
+        7: properties[LED_BRIGHTNESS],
+        8: properties[BRIGHTNESS_MAX],
+        9: properties[BRIGHTNESS_MIN],
+        10: properties[BRIGHTNESS_START],
+        11: properties[NIGHT_MODE_MAX_LEVEL],
+        12: properties[NIGHT_MODE_LED_BRIGHTNESS],
+        13: properties[NIGHT_MODE_RAMP_RATE],
+    }
 
 
 # pylint: disable=no-member
@@ -139,13 +157,13 @@ class I3Base:
     async def async_read_ext_properties(self, group=None) -> ResponseStatus:
         """Get the device extended properties."""
         responses = []
-        for _, mgr in self._managers[READ_MGRS].items():
+        for mgr in self._managers[READ_MGRS]:
             response = await mgr.async_send()
             responses.append(response)
-        await asyncio.sleep(0.5)
+            await asyncio.sleep(0.2)
         return multiple_status(*responses)
 
-    async def async_write_op_flags(self):
+    async def async_write_op_flags(self) -> ResponseStatus:
         """Write the operating flags to the device."""
         responses = []
         if prop := self._operating_flags.get(NIGHT_MODE_ON):
@@ -156,7 +174,7 @@ class I3Base:
         responses.append(response)
         return multiple_status(*responses)
 
-    async def async_write_ext_properties(self):
+    async def async_write_ext_properties(self) -> ResponseStatus:
         """Write the extended properties."""
         responses = [ResponseStatus.SUCCESS]
         for cmd in self._managers[WRITE_MGRS]:
@@ -172,14 +190,57 @@ class I3Base:
             await asyncio.sleep(0.5)
         return response
 
-    def _register_handlers_and_managers(self):
+    async def async_factory_reset(self) -> ResponseStatus:
+        """Reset this device to factory defaults."""
+        cmd = FactoryResetCommand(self._address, self._cat, self._subcat)
+        return await cmd.async_send()
+
+    def _register_handlers_and_managers(self) -> None:
         super(I3Base, self)._register_handlers_and_managers()
         self._managers[NIGHT_MODE_ON] = NightModeOnCommand(self._address)
         self._managers[NIGHT_MODE_OFF] = NightModeOffCommand(self._address)
-        self._register_default_ext_prop_read_managers()
+        group_0 = {
+            7: self._properties[RAMP_RATE],
+            8: self._properties[ON_LEVEL],
+            9: self._properties[LED_BRIGHTNESS],
+        }
+        self._add_ext_prop_read_manager(
+            properties=group_0,
+            cmd2=0x00,
+            data1_read=0x00,
+            data2_read=0x00,
+            data3_read=0x00,
+            data1_resp=0x00,
+            data2_resp=0x01,
+            data3_resp=None,
+        )
+
+        # Cat   Subcat  Model   Device      Data1
+        # 0x01  0x57    PS01    i3 Paddle   0x05
+        # 0x01	0x58    DS01    i3 Dial     0x04
+        # 0x01	0x59    KP014   i3 Keypad   0x01
+        # 0x02	0x3F    WR01    i3 Outlet   0x03
+        data2_map = {
+            0x57: 0x05,
+            0x58: 0x04,
+            0x59: 0x01,
+            0x3F: 0x03,
+        }
+        group_1 = _group_1_properties(self._properties)
+        if data1_resp := data2_map.get(self._subcat):
+            self._add_ext_prop_read_manager(
+                properties=group_1,
+                cmd2=0x01,
+                data1_read=0x00,
+                data2_read=0x00,
+                data3_read=0x00,
+                data1_resp=data1_resp,
+                data2_resp=None,
+                data3_resp=None,
+            )
         self._register_default_ext_prop_write_managers()
 
-    def _subscribe_to_handelers_and_managers(self):
+    def _subscribe_to_handelers_and_managers(self) -> None:
         super(I3Base, self)._subscribe_to_handelers_and_managers()
         self._managers[NIGHT_MODE_ON].subscribe(self._handle_night_mode)
         self._managers[NIGHT_MODE_OFF].subscribe(self._handle_night_mode)
@@ -195,7 +256,7 @@ class I3Base:
         ops_flags_1: Dict[int, str],
         ops_flags_2: Dict[int, str],
         ops_flags_3: Dict[int, str],
-    ):
+    ) -> None:
         for flag in _default_ops_flags(dimmable):
             self._add_operating_flag(
                 name=flag.name,
@@ -215,20 +276,8 @@ class I3Base:
                 is_read_only=prop.is_read_only,
                 prop_type=prop.prop_type,
             )
-        # Dummy flag needed for Extended Properties group 1
-        self._operating_flags[MOD_SYNC_SYNC] = OperatingFlag(
-            address=self._address,
-            name=MOD_SYNC_SYNC,
-            value_type=bool,
-            prop_type=PropertyType.HIDDEN,
-        )
-        self._operating_flags[NIGHT_LEDS_ON] = OperatingFlag(
-            address=self._address,
-            name=NIGHT_LEDS_ON,
-            value_type=bool,
-            prop_type=PropertyType.HIDDEN,
-        )
-        ops_flags_1_all = {
+
+        ops_flags_1f_00_all = {
             0: PROGRAM_LOCK_ON,
             1: LED_BLINK_ON_TX_ON,
             4: LED_OFF,
@@ -236,8 +285,8 @@ class I3Base:
             6: RF_DISABLE_ON,
             7: INSTEON_OFF,
         }
-        ops_flags_1_all.update(ops_flags_1)
-        ops_flags_2_all = {
+        ops_flags_1f_00_all.update(ops_flags_1)
+        ops_flags_1f_05_all = {
             1: NIGHT_MODE_ON,
             2: LED_BLINK_ON_ERROR_ON,
             3: CLEANUP_REPORT_OFF,
@@ -246,21 +295,22 @@ class I3Base:
             6: ACK_A_SCENE,
             7: RELAY_MODE_OFF,
         }
-        ops_flags_2_all.update(ops_flags_2)
-        ops_flags_3_all = {
+        ops_flags_1f_05_all.update(ops_flags_2)
+        ops_flags_1f_07_all = {
             0: YAKETY_YAK,
-            1: MOD_SYNC_SYNC,
+            1: RED_LED_OFF,
             2: SKIP_SOME_HOPS,
-            3: RELAY_MODE_OFF,
-            4: NIGHT_LEDS_ON,
+            3: GREEN_LED_OFF,
+            4: BLUE_LED_OFF,
             5: NO_CACHE,
+            6: DO_NOT_ROTATE_TO_OFF,
         }
-        ops_flags_3_all.update(ops_flags_3)
-        self._add_extended_prop_byte(OP_FLAG_PROP_1, ops_flags_1_all)
-        self._add_extended_prop_byte(OP_FLAG_PROP_2, ops_flags_2_all)
-        self._add_extended_prop_byte(OP_FLAG_PROP_3, ops_flags_3_all)
+        ops_flags_1f_07_all.update(ops_flags_3)
+        self._add_extended_prop_byte(OP_FLAG_1F_00, ops_flags_1f_00_all)
+        self._add_extended_prop_byte(OP_FLAG_1F_05, ops_flags_1f_05_all)
+        self._add_extended_prop_byte(OP_FLAG_1F_07, ops_flags_1f_07_all)
 
-    def _add_extended_prop_byte(self, name: str, op_flag_map: Dict[int, str]):
+    def _add_extended_prop_byte(self, name: str, op_flag_map: Dict[int, str]) -> None:
         """Add an extended property to hold the operating flags used in an extended write."""
         ops_flags = {
             index: self._operating_flags[name] for index, name in op_flag_map.items()
@@ -269,78 +319,69 @@ class I3Base:
             address=self._address, name=name, flags=ops_flags
         )
 
-    def _register_default_ext_prop_read_managers(self):
-        group_0 = {
-            7: self._properties[RAMP_RATE],
-            8: self._properties[ON_LEVEL],
-            9: self._properties[LED_BRIGHTNESS],
-        }
-        self._managers[READ_MGRS] = self._managers.get(READ_MGRS, {})
-        self._managers[READ_MGRS][0] = ExtendedPropertyReadManager(
-            address=self._address,
-            properties=group_0,
-            cmd2=0x00,
-            data1_read=0x00,
-            data2_read=0x00,
-            data3_read=0x00,
-            data1_resp=0x00,
-            data2_resp=0x01,
-            data3_resp=None,
-        )
-        group_1 = {
-            # 2: self._properties[OP_FLAG_PROP_1],
-            # 3: self._properties[OP_FLAG_PROP_2],
-            # 4: self._properties[OP_FLAG_PROP_3],
-            # 5: self._properties[RAMP_RATE],
-            # 6: self._properties[ON_LEVEL],
-            # 7: self._properties[LED_BRIGHTNESS],
-            8: self._properties[BRIGHTNESS_MAX],
-            9: self._properties[BRIGHTNESS_MIN],
-            10: self._properties[BRIGHTNESS_START],
-            11: self._properties[NIGHT_MODE_MAX_LEVEL],
-            12: self._properties[NIGHT_MODE_LED_BRIGHTNESS],
-            13: self._properties[NIGHT_MODE_RAMP_RATE],
-        }
-        self._managers[READ_MGRS][1] = ExtendedPropertyReadManager(
-            address=self._address,
-            properties=group_1,
-            cmd2=0x01,
-            data1_read=0x00,
-            data2_read=0x00,
-            data3_read=None,
-            data1_resp=0x04,
-            data2_resp=None,
-            data3_resp=None,
-        )
-
-    def _register_default_ext_prop_write_managers(self):
-        self._managers[WRITE_MGRS] = self._managers.get(WRITE_MGRS, [])
-
-        led = {3: self._properties[LED_BRIGHTNESS]}
-        self._managers[WRITE_MGRS].append(
-            ExtendedPropertyWriteManager(
-                address=self._address, properties=led, cmd2=0, data1=0x01, data2=0x07
-            )
-        )
-
-        on_level = {3: self._properties[ON_LEVEL]}
-        self._managers[WRITE_MGRS].append(
-            ExtendedPropertyWriteManager(
+    def _add_ext_prop_read_manager(
+        self,
+        properties: Dict[int, ExtendedProperty],
+        cmd2: int = 0,
+        data1_read: int = 0,
+        data2_read: int = 0,
+        data3_read: int = None,
+        data1_resp: int = 0,
+        data2_resp: int = 1,
+        data3_resp: int = None,
+    ) -> None:
+        self._managers[READ_MGRS] = self._managers.get(READ_MGRS, [])
+        self._managers[READ_MGRS].append(
+            ExtendedPropertyReadManager(
                 address=self._address,
-                properties=on_level,
-                cmd2=0,
-                data1=0x01,
-                data2=0x06,
+                properties=properties,
+                cmd2=cmd2,
+                data1_read=data1_read,
+                data2_read=data2_read,
+                data3_read=data3_read,
+                data1_resp=data1_resp,
+                data2_resp=data2_resp,
+                data3_resp=data3_resp,
             )
+        )
+
+    def _register_default_ext_prop_write_managers(self) -> None:
+        led = {3: self._properties[LED_BRIGHTNESS]}
+        self._add_ext_prop_write_manager(properties=led, cmd2=0, data1=0x01, data2=0x07)
+        on_level = {3: self._properties[ON_LEVEL]}
+        self._add_ext_prop_write_manager(
+            properties=on_level,
+            cmd2=0,
+            data1=0x01,
+            data2=0x06,
         )
         ramp_rate = {3: self._properties[RAMP_RATE]}
+        self._add_ext_prop_write_manager(
+            properties=ramp_rate,
+            cmd2=0,
+            data1=0x01,
+            data2=0x05,
+        )
+        group_1 = _group_1_properties(self._properties)
+        self._add_ext_prop_write_manager(
+            properties=group_1, data2=None, cmd2=0x01, data1=0x02
+        )
+
+    def _add_ext_prop_write_manager(
+        self,
+        properties: Dict[int, ExtendedProperty],
+        data2: Union[int, None],
+        cmd2: int = 0,
+        data1: int = 0,
+    ) -> None:
+        self._managers[WRITE_MGRS] = self._managers.get(WRITE_MGRS, [])
         self._managers[WRITE_MGRS].append(
             ExtendedPropertyWriteManager(
                 address=self._address,
-                properties=ramp_rate,
-                cmd2=0,
-                data1=0x01,
-                data2=0x05,
+                properties=properties,
+                cmd2=cmd2,
+                data1=data1,
+                data2=data2,
             )
         )
 

--- a/pyinsteon/device_types/i3_base.py
+++ b/pyinsteon/device_types/i3_base.py
@@ -287,31 +287,31 @@ class I3Base:
             data2_resp=0x01,
             data3_resp=None,
         )
-        # group_1 = {
-        #     2: self._properties[OP_FLAG_PROP_1],
-        #     3: self._properties[OP_FLAG_PROP_2],
-        #     4: self._properties[OP_FLAG_PROP_3],
-        #     # 5: self._properties[RAMP_RATE],
-        #     # 6: self._properties[ON_LEVEL],
-        #     # 7: self._properties[LED_BRIGHTNESS],
-        #     8: self._properties[BRIGHTNESS_MAX],
-        #     9: self._properties[BRIGHTNESS_MIN],
-        #     10: self._properties[BRIGHTNESS_START],
-        #     11: self._properties[NIGHT_MODE_MAX_LEVEL],
-        #     12: self._properties[NIGHT_MODE_LED_BRIGHTNESS],
-        #     13: self._properties[NIGHT_MODE_RAMP_RATE],
-        # }
-        # self._managers[READ_MGRS][1] = ExtendedPropertyReadManager(
-        #     address=self._address,
-        #     properties=group_1,
-        #     cmd2=0x01,
-        #     data1_read=0x00,
-        #     data2_read=0x00,
-        #     data3_read=0x00,
-        #     data1_resp=0x01,
-        #     data2_resp=None,
-        #     data3_resp=None,
-        # )
+        group_1 = {
+            # 2: self._properties[OP_FLAG_PROP_1],
+            # 3: self._properties[OP_FLAG_PROP_2],
+            # 4: self._properties[OP_FLAG_PROP_3],
+            # 5: self._properties[RAMP_RATE],
+            # 6: self._properties[ON_LEVEL],
+            # 7: self._properties[LED_BRIGHTNESS],
+            8: self._properties[BRIGHTNESS_MAX],
+            9: self._properties[BRIGHTNESS_MIN],
+            10: self._properties[BRIGHTNESS_START],
+            11: self._properties[NIGHT_MODE_MAX_LEVEL],
+            12: self._properties[NIGHT_MODE_LED_BRIGHTNESS],
+            13: self._properties[NIGHT_MODE_RAMP_RATE],
+        }
+        self._managers[READ_MGRS][1] = ExtendedPropertyReadManager(
+            address=self._address,
+            properties=group_1,
+            cmd2=0x01,
+            data1_read=0x00,
+            data2_read=0x00,
+            data3_read=None,
+            data1_resp=0x04,
+            data2_resp=None,
+            data3_resp=None,
+        )
 
     def _register_default_ext_prop_write_managers(self):
         self._managers[WRITE_MGRS] = self._managers.get(WRITE_MGRS, [])

--- a/pyinsteon/device_types/switched_lighting_control.py
+++ b/pyinsteon/device_types/switched_lighting_control.py
@@ -30,6 +30,7 @@ from ..config import (
     THREE_WAY_ON,
     TOGGLE_BUTTON,
     TRIGGER_GROUP_MASK,
+    USE_LOCAL_PROFILE,
     X10_HOUSE,
     X10_UNIT,
 )
@@ -663,11 +664,14 @@ class SwitchedLightingControl_I3Outlet(I3Base, SwitchedLightingControl_OnOffOutl
         self._add_operating_flag(
             LOAD_SENSE_2_ON, 0, 3, 6, 7, prop_type=PropertyType.ADVANCED
         )
+        self._add_operating_flag(
+            USE_LOCAL_PROFILE, 7, 7, 0x34, 0x35, prop_type=PropertyType.HIDDEN
+        )
         self._register_default_op_flags_and_props(
             dimmable=False,
             ops_flags_1={2: LOAD_SENSE_ON, 3: LOAD_SENSE_2_ON},
             ops_flags_2={},
-            ops_flags_3={},
+            ops_flags_3={7: USE_LOCAL_PROFILE},
         )
         self._operating_flags[RED_LED_OFF].property_type = PropertyType.HIDDEN
         self._operating_flags[GREEN_LED_OFF].property_type = PropertyType.HIDDEN

--- a/pyinsteon/handlers/from_device/ext_get_response.py
+++ b/pyinsteon/handlers/from_device/ext_get_response.py
@@ -25,7 +25,7 @@ class ExtendedGetResponseHandler(InboundHandlerBase):
         self._data3 = data3
 
         topic = f"handler.{self._address.id}.{EXTENDED_GET_RESPONSE}"
-        for group in [cmd2, data1, data2, data3]:
+        for group in (cmd2, data1, data2, data3):
             if group is None:
                 topic = f"{topic}.x"
             else:

--- a/pyinsteon/handlers/from_device/ext_get_response.py
+++ b/pyinsteon/handlers/from_device/ext_get_response.py
@@ -24,6 +24,14 @@ class ExtendedGetResponseHandler(InboundHandlerBase):
         self._data2 = data2
         self._data3 = data3
 
+        topic = f"handler.{self._address.id}.{EXTENDED_GET_RESPONSE}"
+        for group in [cmd2, data1, data2, data3]:
+            if group is None:
+                topic = f"{topic}.x"
+            else:
+                topic = f"{topic}.{group}"
+        self._subscriber_topic = topic
+
     @inbound_handler
     def handle_response(self, cmd1, cmd2, target, user_data, hops_left):
         """Handle the Extended Get response from a device."""

--- a/pyinsteon/handlers/to_device/extended_get.py
+++ b/pyinsteon/handlers/to_device/extended_get.py
@@ -21,11 +21,15 @@ class ExtendedGetCommand(DirectCommandHandlerBase):
         self._data3 = data3
 
     # pylint: disable=arguments-differ
-    async def async_send(self, group=0):
+    async def async_send(self, group=0, crc=False):
         """Send Get Operating Flags message asyncronously."""
         self._data1 = group
         response = await super().async_send(
-            cmd2=self._cmd2, data1=self._data1, data2=self._data2, data3=self._data3
+            cmd2=self._cmd2,
+            data1=self._data1,
+            data2=self._data2,
+            data3=self._data3,
+            crc=crc,
         )
         self._data1 = None
         return response

--- a/pyinsteon/handlers/to_device/factory_reset.py
+++ b/pyinsteon/handlers/to_device/factory_reset.py
@@ -1,0 +1,26 @@
+"""Factory reset command handler."""
+
+from ...constants import DeviceCategory, ResponseStatus
+from ...topics import FACTORY_RESET
+from .direct_command import DirectCommandHandlerBase
+
+
+class FactoryResetCommand(DirectCommandHandlerBase):
+    """Manage an outbound FACTORY RESET command to a device."""
+
+    def __init__(self, address, cat: DeviceCategory, subcat: int):
+        """Init the OnLevelCommand class."""
+        super().__init__(topic=FACTORY_RESET, address=address)
+        self._cat = DeviceCategory(cat)
+        self._subcat = int(subcat)
+
+    # pylint: disable=arguments-differ
+    async def async_send(self) -> ResponseStatus:
+        """Send the OFF command async."""
+        return await super().async_send(cat=self._cat, subcat=self._subcat)
+
+    def _update_subscribers_on_direct_ack(
+        self, cmd1, cmd2, target, user_data, hops_left
+    ):
+        """Update subscribers."""
+        self._call_subscribers()

--- a/pyinsteon/managers/ext_prop_write_manager.py
+++ b/pyinsteon/managers/ext_prop_write_manager.py
@@ -59,4 +59,5 @@ class ExtendedPropertyWriteManager:
     def _load_prop_values(self):
         """Load the new value to the property value."""
         for _, prop in self._props.items():
-            prop.load(prop.new_value)
+            if prop.is_dirty:
+                prop.load(prop.new_value)

--- a/pyinsteon/managers/get_set_op_flag_manager.py
+++ b/pyinsteon/managers/get_set_op_flag_manager.py
@@ -105,10 +105,9 @@ class GetSetOperatingFlagsManager:
     async def async_write(self):
         """Set the operating flags."""
         results = []
-        for name in self._op_flags:
+        for name, flag_info in self._flags.items():
             if self._op_flags[name].is_dirty:
-                flat_info = self._flags[name]
-                result = await self._async_write(flat_info)
+                result = await self._async_write(flag_info)
                 results.append(result)
         return multiple_status(*results)
 

--- a/pyinsteon/managers/thermostat_status_manager.py
+++ b/pyinsteon/managers/thermostat_status_manager.py
@@ -51,10 +51,10 @@ class GetThermostatStatus:
             address=self._address, cmd2=0x00, data1=0x00, data2=0x00, data3=0x00
         )
         self._status_response = ExtendedGetResponseHandler(
-            self._address, cmd2=0x02, data1=0x00, data2=0x01, data3=None
+            self._address, cmd2=0x02, data1=None, data2=0x01, data3=None
         )
         self._set_point_response = ExtendedGetResponseHandler(
-            self._address, cmd2=0x00, data1=0x00, data2=0x01, data3=0x00
+            self._address, cmd2=0x00, data1=None, data2=0x01, data3=None
         )
         self._response_status = asyncio.Queue()
         self._response_set_point = asyncio.Queue()
@@ -107,7 +107,7 @@ class GetThermostatStatus:
         retries = 3
         response_status = ResponseStatus.FAILURE
         while retries:
-            response = await self._get_status_command.async_send()
+            response = await self._get_status_command.async_send(crc=True)
             if response == ResponseStatus.SUCCESS:
                 try:
                     response_status = await asyncio.wait_for(
@@ -128,7 +128,7 @@ class GetThermostatStatus:
         retries = 3
         response_set_point = ResponseStatus.FAILURE
         while retries:
-            response = await self._get_set_point_command.async_send()
+            response = await self._get_set_point_command.async_send(crc=True)
             if response == ResponseStatus.SUCCESS:
                 try:
                     return await asyncio.wait_for(

--- a/pyinsteon/managers/thermostat_status_manager.py
+++ b/pyinsteon/managers/thermostat_status_manager.py
@@ -48,13 +48,13 @@ class GetThermostatStatus:
         self._address = Address(address)
         self._get_status_command = ExtendedGetCommand(self._address, cmd2=0x02)
         self._get_set_point_command = ExtendedGetCommand(
-            address=self._address, cmd2=0x00, data1=0x00, data2=0x00, data3=0x00
+            address=self._address, cmd2=0x00, data1=0x00, data2=0x00, data3=0x01
         )
         self._status_response = ExtendedGetResponseHandler(
-            self._address, cmd2=0x02, data1=None, data2=0x01, data3=None
+            self._address, cmd2=0x02, data1=0x01, data2=None, data3=None
         )
         self._set_point_response = ExtendedGetResponseHandler(
-            self._address, cmd2=0x00, data1=None, data2=0x01, data3=None
+            self._address, cmd2=0x00, data1=0x00, data2=0x01, data3=0x01
         )
         self._response_status = asyncio.Queue()
         self._response_set_point = asyncio.Queue()

--- a/pyinsteon/protocol/command_to_msg.py
+++ b/pyinsteon/protocol/command_to_msg.py
@@ -6,6 +6,7 @@ from .. import pub
 from ..address import Address
 from ..commands import commands
 from ..constants import (
+    DeviceCategory,
     DoorCommand,
     IOModuleControlCommand,
     PoolControlCommand,
@@ -33,6 +34,7 @@ from ..topics import (
     EXTENDED_GET_SET,
     EXTENDED_READ_WRITE_ALDB,
     EXTENDED_TRIGGER_ALL_LINK,
+    FACTORY_RESET,
     FX_USERNAME,
     GET_INSTEON_ENGINE_VERSION,
     GET_OPERATING_FLAGS,
@@ -558,6 +560,20 @@ def extended_trigger_all_link(
 def beep(address: Address, topic=pub.AUTO_TOPIC):
     """Create a BEEP command."""
     _create_direct_message(topic=topic, address=address)
+
+
+@topic_to_command_handler(register_list=COMMAND_REGISTER, topic=FACTORY_RESET)
+def factory_reset(
+    address: Address, cat: DeviceCategory, subcat: int, topic=pub.AUTO_TOPIC
+):
+    """Create a FACTORY RESET command."""
+    user_data = UserData(
+        {
+            "d1": int(cat),
+            "d2": subcat,
+        }
+    )
+    _create_direct_message(topic=topic, address=address, user_data=user_data)
 
 
 @topic_to_command_handler(register_list=COMMAND_REGISTER, topic=NIGHT_MODE_OFF)

--- a/pyinsteon/tools/tools_base.py
+++ b/pyinsteon/tools/tools_base.py
@@ -42,6 +42,7 @@ ARG_TYPES = {
     "master": Address,
     "monitor_mode": bool,
     "on_level": bytes,
+    "on": bool,
     "open_level": bytes,
     "relay_mode": RelayMode,
     "seconds": bytes,

--- a/pyinsteon/topics.py
+++ b/pyinsteon/topics.py
@@ -129,6 +129,7 @@ SET_SPRINKLER_PROGRAM = "set_sprinkler_program"
 SPRINKLER_GET_PROGRAM_RESPONSE = "sprinkler_get_program_response"
 IO_SET_SENSOR_NOMINAL_VALUE = "io_set_sensor_nominal_value"
 IO_ALARM_DATA_RESPONSE = "io_alarm_data_response"
+FACTORY_RESET = "factory_reset"
 
 ALDB_LINK_CHANGED = "aldb.link_changed"
 

--- a/tests/test_device_config/test_op_flag_prop_byte.py
+++ b/tests/test_device_config/test_op_flag_prop_byte.py
@@ -1,0 +1,85 @@
+"""Test the OpFlagPropertyByte class."""
+from random import randint
+from unittest import TestCase
+
+from pyinsteon.config.op_flag_property_byte import OpFlagPropertyByte
+from pyinsteon.config.operating_flag import OperatingFlag
+from pyinsteon.utils import bit_is_set, set_bit
+
+from ..utils import random_address
+
+
+class TestOpFlagPropertyByte(TestCase):
+    """Test the OpFlagPropertyByte class."""
+
+    def setUp(self) -> None:
+        """Set up the tests."""
+        address = random_address()
+        flag0 = OperatingFlag(address=address, name="byte0", value_type=bool)
+        # No bit 1 flag exists
+        flag2 = OperatingFlag(address=address, name="byte2", value_type=bool)
+        flag3 = OperatingFlag(address=address, name="byte3", value_type=bool)
+        flag4 = OperatingFlag(address=address, name="byte4", value_type=bool)
+        flag5 = OperatingFlag(address=address, name="byte5", value_type=bool)
+        flag6 = OperatingFlag(address=address, name="byte6", value_type=bool)
+        flag7 = OperatingFlag(address=address, name="byte7", value_type=bool)
+        self.flags = {
+            0: flag0,
+            2: flag2,
+            3: flag3,
+            4: flag4,
+            5: flag5,
+            6: flag6,
+            7: flag7,
+        }
+        self.prop_byte = OpFlagPropertyByte(
+            address=address, name="prop_byte", flags=self.flags
+        )
+
+    def test_flag_to_byte(self):
+        """Test converting a set of flags to a byte."""
+        for _ in range(0, 20):
+            value = randint(1, 255)
+            value = set_bit(value, 1, False)
+            for bit, flag in self.flags.items():
+                bit_value = bit_is_set(value, bit)
+                flag.load(bit_value)
+            assert self.prop_byte.value == value
+
+    def test_byte_to_flag(self):
+        """Test converting a byte to a set of flags."""
+        for _ in range(0, 20):
+            value = randint(1, 255)
+            self.prop_byte.load(value)
+            for bit, flag in self.flags.items():
+                assert flag.value == bit_is_set(value, bit)
+
+    def test_new_value_to_byte(self):
+        """Test setting a new value to a byte value."""
+        init_value = randint(1, 255)
+        init_bit_1 = bit_is_set(init_value, 1)
+        self.prop_byte.load(init_value)
+        for _ in range(0, 20):
+            new_value = randint(1, 255)
+            for bit, flag in self.flags.items():
+                flag.new_value = bit_is_set(new_value, bit)
+            assert self.prop_byte.new_value == set_bit(new_value, 1, init_bit_1)
+
+    def test_missing_ops_flag(self):
+        """Test when one bit has no associated operating flag."""
+
+        prop_byte = OpFlagPropertyByte(
+            address=random_address(), name="prop_byte", flags=self.flags
+        )
+
+        # Test that a missing bit loads and is represented in the output
+        init_value = randint(1, 255)
+        init_value = set_bit(init_value, 1, True)
+        prop_byte.load(init_value)
+        assert bit_is_set(prop_byte.value, 1)
+
+        # Test that a missing bit never changes even if new_value changes it
+        new_value = set_bit(init_value, 1, False)
+        assert new_value != init_value
+        prop_byte.new_value = new_value
+        assert bit_is_set(prop_byte.new_value, 1)

--- a/tests/test_managers/test_thermostat_status_manager.py
+++ b/tests/test_managers/test_thermostat_status_manager.py
@@ -1,5 +1,6 @@
 """Test the Thermostat status manager."""
 import asyncio
+from random import randint
 from unittest import TestCase
 from unittest.mock import AsyncMock
 
@@ -62,7 +63,7 @@ class TestThermostatStatusManager(TestCase):
         ack_topic = f"ack.{address.id}.{EXTENDED_GET_SET}.direct"
         dir_ack_topic = f"{address.id}.{EXTENDED_GET_SET}.direct_ack"
         response_topic = f"{address.id}.{EXTENDED_GET_RESPONSE}.direct"
-        ud_status_ack = UserData()
+        ud_status_ack = UserData({"d13": 0x92, "d14": 0x96})
         ack_status = TopicItem(
             ack_topic, {"cmd1": 0x2E, "cmd2": 0x02, "user_data": ud_status_ack}, 0.2
         )
@@ -79,18 +80,18 @@ class TestThermostatStatusManager(TestCase):
         )
         user_data_response = UserData(
             {
-                "d1": 0x00,
-                "d2": 0x01,
-                "d3": 0x03,
-                "d4": 0x04,
-                "d5": 0x05,
-                "d6": 0x06,
-                "d7": 0x07,
-                "d8": 0x08,
-                "d9": 0x09,
-                "d10": 0x0A,
-                "d11": 0x0B,
-                "d12": 0x0C,
+                "d1": 0x01,
+                "d2": randint(20, 255),
+                "d3": randint(20, 255),
+                "d4": randint(20, 255),
+                "d5": randint(20, 255),
+                "d6": randint(20, 255),
+                "d7": randint(20, 255),
+                "d8": randint(20, 255),
+                "d9": randint(20, 255),
+                "d10": randint(20, 255),
+                "d11": randint(20, 255),
+                "d12": randint(20, 255),
             }
         )
         status_response = TopicItem(
@@ -105,7 +106,7 @@ class TestThermostatStatusManager(TestCase):
             1,
         )
 
-        ud_setpt_ack = UserData()
+        ud_setpt_ack = UserData({"d3": 0x01, "d13": 0x20, "d14": 0x0F})
         ack_setpt = TopicItem(
             ack_topic, {"cmd1": 0x2E, "cmd2": 0x00, "user_data": ud_setpt_ack}, 0.1
         )
@@ -124,16 +125,16 @@ class TestThermostatStatusManager(TestCase):
             {
                 "d1": 0x00,
                 "d2": 0x01,
-                "d3": 0x00,
-                "d4": 0x04,
-                "d5": 0x05,
-                "d6": 0x06,
-                "d7": 0x07,
-                "d8": 0x08,
-                "d9": 0x09,
-                "d10": 0x0A,
-                "d11": 0x0B,
-                "d12": 0x0C,
+                "d3": 0x01,
+                "d4": randint(20, 255),
+                "d5": randint(20, 255),
+                "d6": randint(20, 255),
+                "d7": randint(20, 255),
+                "d8": randint(20, 255),
+                "d9": randint(20, 255),
+                "d10": randint(20, 255),
+                "d11": randint(20, 255),
+                "d12": randint(20, 255),
             }
         )
         setpt_response = TopicItem(

--- a/tests/test_messages/msg_to_cmd.json
+++ b/tests/test_messages/msg_to_cmd.json
@@ -441,6 +441,16 @@
         "ack": "",
         "topic": "{}.beep.direct"
     },
+    "FACTORY_RESET-DIRECT": {
+        "address": {},
+        "target": "040506",
+        "flags": "00",
+        "cmd1": "34",
+        "cmd2": "",
+        "user_data": "",
+        "ack": "",
+        "topic": "{}.factory_reset.direct"
+    },
     "SET_SPRINKLER_PROGRAM-DIRECT": {
         "address": {},
         "target": "040506",

--- a/tests/test_messages/test_outbound/outbound_commands.json
+++ b/tests/test_messages/test_outbound/outbound_commands.json
@@ -229,6 +229,14 @@
         "args": {},
         "result": "0262aaaaaa0f30"
     },
+    "FACTORY_RESET": {
+        "topic": "factory_reset",
+        "args": {
+            "cat": "0x01",
+            "subcat": "0x02"
+        },
+        "result": "0262aaaaaa1f34000102"
+    },
     "SET_SPRINKLER_PROGRAM": {
         "topic": "set_sprinkler_program",
         "args": {


### PR DESCRIPTION
Make the following i3 properties visible to the user:
- NIGHT_MODE_ON
- RELAY_MODE_OFF
- NIGHT_MODE_LED_BRIGHTNESS
- NIGHT_MODE_RAMP_RATE
- BRIGHTNESS_MIN
- BRIGHTNESS_MAX
- BRIGHTNESS_START
- NIGHT_MODE_MAX_LEVEL

Fix the issue with thermostat status reporting during startup