### PR TITLE
Use dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,21 +5,21 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: pylint
-    versions:
-    - 2.6.0
-    - 2.6.2
-    - 2.7.0
-    - 2.7.1
-    - 2.7.2
-    - 2.7.3
-    - 2.7.4
-    - 2.8.1
-  - dependency-name: flake8
-    versions:
-    - 3.8.4
-    - 3.9.0
-  - dependency-name: pydocstyle
-    versions:
-    - 5.1.1
+  groups:
+    dev-dependencies:
+      patterns:
+        - "flake8-docstrings"
+        - "flake8"
+        - "flake8-noqa"
+        - "flake8-comprehensions"
+        - "pyflakes"
+        - "pycodestyle"
+        - "pydocstyle"
+        - "pylint"
+        - "isort"
+        - "async_generator"
+        - "black"
+        - "pytest-cov"
+        - "pytest"
+        - "pre-commit"
+

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,15 +3,15 @@
 # new version
 flake8-docstrings==1.7.0
 flake8==6.0.0
-flake8-noqa==1.3.1
-flake8-comprehensions==3.12.0
+flake8-noqa==1.3.2
+flake8-comprehensions==3.14.0
 pyflakes==3.0.1
 pycodestyle==2.10.0
 pydocstyle==6.3.0
 pylint==2.17.4
 isort==5.12.0
 async_generator
-black==23.3.0
-pytest-cov==4.0.0
-pytest==7.3.1
-pre-commit==3.3.1
+black==23.7.0
+pytest-cov==4.1.0
+pytest==7.4.0
+pre-commit==3.3.3


### PR DESCRIPTION
Update all dev dependencies to the latest versions and start using dependabot groups for these dependencies to reduce the number of PRs.