### PR TITLE
Respond to cleanup messages for device links

### DIFF
--- a/pyinsteon/managers/device_link_manager.py
+++ b/pyinsteon/managers/device_link_manager.py
@@ -217,9 +217,12 @@ class DeviceLinkManager:
             return
         if group == 0:
             return
+        _LOGGER.debug("Checking links for controller %s group %s", controller, group)
         if self._is_duplicate_message(controller, group, command):
+            _LOGGER.debug("Duplicate message.")
             return
         responder_data = self.get_responders(controller, group)
+        _LOGGER.debug("Found responders %s", list(responder_data))
         for addr, data_list in responder_data.items():
             device = self._devices[addr]
             if device:

--- a/pyinsteon/managers/device_link_manager.py
+++ b/pyinsteon/managers/device_link_manager.py
@@ -1,7 +1,6 @@
 """Manages links between devices to identify device state of responders."""
 import asyncio
 from datetime import datetime, timedelta
-import logging
 from typing import Dict, Tuple, Union
 
 import voluptuous as vol
@@ -13,7 +12,6 @@ from ..constants import AllLinkMode, DeviceAction, MessageFlagType
 from ..topics import ALDB_LINK_CHANGED
 from ..utils import subscribe_topic, unsubscribe_topic
 
-_LOGGER = logging.getLogger(__name__)
 TIMEOUT_DUPLICATE = timedelta(seconds=10)
 ControllerAddress = Address
 ResponderAddress = Address


### PR DESCRIPTION
Fix an error where only the broadcast message was being used to determine a linked device changed. This update uses the cleanup messages also in order to better respond to device changes and linked device responses.