### PR TITLE
Break on ALDB read Direct NAK

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,4 @@
 {
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+  "python.testing.unittestEnabled": true,
+  "python.testing.pytestEnabled": false
 }

--- a/pyinsteon/managers/aldb_read_manager.py
+++ b/pyinsteon/managers/aldb_read_manager.py
@@ -98,7 +98,6 @@ class ALDBReadManager:
             if response in [
                 ResponseStatus.DIRECT_NAK_ALDB,
                 ResponseStatus.DIRECT_NAK_INVALID_COMMAND,
-                ResponseStatus.DIRECT_NAK_INVALID_COMMAND,
                 ResponseStatus.DIRECT_NAK_CHECK_SUM,
             ]:
                 # When Checksum direct NAK, should we change the checksum method?
@@ -183,7 +182,6 @@ class ALDBReadManager:
                     pass
             elif result in [
                 ResponseStatus.DIRECT_NAK_ALDB,
-                ResponseStatus.DIRECT_NAK_INVALID_COMMAND,
                 ResponseStatus.DIRECT_NAK_INVALID_COMMAND,
                 ResponseStatus.DIRECT_NAK_CHECK_SUM,
             ]:

--- a/pyinsteon/managers/aldb_read_manager.py
+++ b/pyinsteon/managers/aldb_read_manager.py
@@ -134,6 +134,8 @@ class ALDBReadManager:
                 value = await self._async_peek(mem_addr=mem_addr - curr_byte)
                 if value is None:
                     break
+                if value == -1:
+                    return None
                 record.append(value)
             if len(record) == 8:
                 flags = AllLinkRecordFlags(record[7])
@@ -179,6 +181,19 @@ class ALDBReadManager:
                             return value
                 except asyncio.TimeoutError:
                     pass
+            elif result in [
+                ResponseStatus.DIRECT_NAK_ALDB,
+                ResponseStatus.DIRECT_NAK_INVALID_COMMAND,
+                ResponseStatus.DIRECT_NAK_INVALID_COMMAND,
+                ResponseStatus.DIRECT_NAK_CHECK_SUM,
+            ]:
+                # When Checksum direct NAK, should we change the checksum method?
+                _LOGGER.error(
+                    "Device refused the ALDB Read command with error: %s (%r)",
+                    result,
+                    result,
+                )
+                return -1
             retries_byte -= 1
             _LOGGER.debug("Retrying byte at 0x%04X", mem_addr)
         return None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,7 +13,7 @@ from pyinsteon.managers.device_manager import DeviceManager
 _LOGGER = logging.getLogger(__name__)
 _LOGGER_PYINSTEON = logging.getLogger("pyinsteon")
 _LOGGER_MESSAGES = logging.getLogger("pyinsteon.messages")
-_LOGGER_TOPICS = logging.getLogger("topics")
+_LOGGER_TOPICS = logging.getLogger("pyinsteon.topics")
 PATH = os.path.join(os.getcwd())
 
 
@@ -59,12 +59,7 @@ def set_log_levels(
     _setup_logger(_LOGGER, logger)
     _setup_logger(_LOGGER_PYINSTEON, logger_pyinsteon)
     _setup_logger(_LOGGER_MESSAGES, logger_messages)
-    if logger_topics:
-        _setup_logger(_LOGGER_TOPICS, "info")
-        pub.subscribe(_log_all_topics, pub.ALL_TOPICS)
-    else:
-        _setup_logger(_LOGGER_TOPICS, "fatal")
-        pub.unsubscribe(_log_all_topics, pub.ALL_TOPICS)
+    _LOGGER_TOPICS.setLevel(logging.DEBUG if logger_topics else logging.CRITICAL)
 
 
 async def load_devices(devices_mgr: DeviceManager):

--- a/tests/test_managers/test_aldb_read_manager.py
+++ b/tests/test_managers/test_aldb_read_manager.py
@@ -280,6 +280,80 @@ class TestAldbReadManager(unittest.TestCase):
                 await mgr.async_stop()
 
     @async_case
+    async def test_read_all_standard_direct_nak(self):
+        """Test reading all records using the standard method with a Direct NAK response."""
+        address = random_address()
+        mgr = ALDBReadManager(address=address, first_record=0x0FFF)
+        user_data = UserData({"d1": 0x00, "d2": 0x00, "d3": 0, "d4": 0, "d5": 0})
+
+        ack_topic = f"ack.{address.id}.{EXTENDED_READ_WRITE_ALDB}.direct"
+        ack_topic_item = TopicItem(
+            ack_topic, {"cmd1": 0x2F, "cmd2": 0, "user_data": user_data}, 0.5
+        )
+
+        dir_nak_topic = f"{address.id}.{EXTENDED_READ_WRITE_ALDB}.direct_nak"
+        dir_nak_topic_item = TopicItem(
+            dir_nak_topic,
+            {
+                "cmd1": 0x2F,
+                "cmd2": 0xFD,
+                "target": MODEM_ADDRESS,
+                "user_data": None,
+                "hops_left": 3,
+            },
+            0.5,
+        )
+        topic_items = [ack_topic_item, dir_nak_topic_item]
+
+        send_topics(topic_items)
+        async with async_timeout.timeout(3):
+            try:
+                async for _ in mgr.async_read():
+                    assert False
+            except asyncio.TimeoutError:
+                assert False
+
+    @async_case
+    async def test_read_one_standard_direct_nak(self):
+        """Test reading one record using the standard method with a direct NAK."""
+        address = random_address()
+        mgr = ALDBReadManager(address=address, first_record=0x0FFF)
+        mem_addr = 0x0FFF
+
+        mem_hi = mem_addr >> 8
+        mem_lo = mem_addr & 0xFF
+        user_data = UserData(
+            {"d1": 0x00, "d2": 0x00, "d3": mem_hi, "d4": mem_lo, "d5": 1}
+        )
+
+        ack_topic = f"ack.{address.id}.{EXTENDED_READ_WRITE_ALDB}.direct"
+        ack_topic_item = TopicItem(
+            ack_topic, {"cmd1": 0x2F, "cmd2": 0, "user_data": user_data}, 0.5
+        )
+
+        dir_nak_topic = f"{address.id}.{EXTENDED_READ_WRITE_ALDB}.direct_nak"
+        dir_nak_topic_item = TopicItem(
+            dir_nak_topic,
+            {
+                "cmd1": 0x2F,
+                "cmd2": 0xFB,
+                "target": MODEM_ADDRESS,
+                "user_data": None,
+                "hops_left": 3,
+            },
+            0.5,
+        )
+
+        send_topics([ack_topic_item, dir_nak_topic_item])
+
+        async with async_timeout.timeout(3):
+            try:
+                async for _ in mgr.async_read(mem_addr=mem_addr, num_recs=1):
+                    assert False
+            except asyncio.TimeoutError:
+                assert False
+
+    @async_case
     async def test_read_one_peek_direct_nak(self):
         """Test peek record with direct nak response."""
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,7 +17,7 @@ from pyinsteon.address import Address
 from pyinsteon.protocol.messages.inbound import create
 import pyinsteon.protocol.protocol
 
-from tests import _LOGGER_MESSAGES, async_connect_mock
+from tests import _LOGGER_MESSAGES, _LOGGER_TOPICS, async_connect_mock
 
 
 def hex_to_inbound_message(hex_data):
@@ -61,7 +61,7 @@ def send_topics(topic_items):
     async def async_send_topics(topic_items):
         for item in topic_items:
             await asyncio.sleep(item.delay)
-            _LOGGER_MESSAGES.debug("RX: %s  %s", item.topic, item.kwargs)
+            _LOGGER_TOPICS.debug("Topic: %s  %s", item.topic, item.kwargs)
             pub.sendMessage(item.topic, **item.kwargs)
 
     asyncio.ensure_future(async_send_topics(topic_items))


### PR DESCRIPTION
If an ALDB read command receives a Direct NAK for ALDB, CheckSum or Invalid Command, the process should stop