### PR TITLE
Status improvements

### DIFF
--- a/pyinsteon/device_types/access_control.py
+++ b/pyinsteon/device_types/access_control.py
@@ -1,6 +1,5 @@
 """Access control device types."""
 
-
 from ..events import OFF_EVENT, OFF_FAST_EVENT, ON_EVENT, ON_FAST_EVENT
 from ..groups import ON_OFF_SWITCH
 from .on_off_responder_base import OnOffResponderBase
@@ -25,7 +24,7 @@ class AccessControl_Morningstar(OnOffResponderBase):
         off_fast_event_name=OFF_FAST_EVENT,
     ):
         """Init the OnOffResponderBase class."""
-        buttons = {1: ON_OFF_SWITCH} if buttons is None else buttons
+        buttons = {1: (ON_OFF_SWITCH, 0)} if buttons is None else buttons
         super().__init__(
             address,
             cat,

--- a/pyinsteon/device_types/climate_control.py
+++ b/pyinsteon/device_types/climate_control.py
@@ -1,4 +1,5 @@
 """Thermostat device types."""
+
 from datetime import datetime
 import logging
 
@@ -91,11 +92,6 @@ class ClimateControl_Thermostat(Device):
             model=model,
         )
         self._aldb = ALDB(self._address, mem_addr=0x1FFF)
-
-    # pylint: disable=arguments-differ
-    async def async_status(self, group=None):
-        """Get the status of the device."""
-        return await self._managers[STATUS_COMMAND].async_status()
 
     async def async_set_cool_set_point(self, temperature):
         """Set the cool set point."""

--- a/pyinsteon/device_types/device_base.py
+++ b/pyinsteon/device_types/device_base.py
@@ -11,12 +11,14 @@ from ..config.extended_property import ExtendedProperty
 from ..config.operating_flag import OperatingFlag
 from ..constants import DeviceCategory, EngineVersion, PropertyType, ResponseStatus
 from ..default_link import DefaultLink
+from ..device_types.device_commands import STATUS_COMMAND
 from ..handlers.to_device.engine_version_request import EngineVersionRequest
 from ..handlers.to_device.ping import PingCommand
 from ..handlers.to_device.product_data_request import ProductDataRequestCommand
 from ..managers.get_set_ext_property_manager import GetSetExtendedPropertyManager
 from ..managers.get_set_op_flag_manager import GetSetOperatingFlagsManager
 from ..managers.link_manager.default_links import async_add_default_links
+from ..managers.status_manager import StatusManager
 from ..topics import ENGINE_VERSION
 from ..utils import multiple_status, publish_topic
 
@@ -176,6 +178,7 @@ class Device(ABC):
 
     async def async_status(self, group=None):
         """Get the status of the device."""
+        return ResponseStatus.SUCCESS
 
     async def async_read_config(self, read_aldb: bool = True):
         """Get all configuration settings.
@@ -243,6 +246,7 @@ class Device(ABC):
         """Add all handlers to the device and register listeners."""
         self._handlers["product_data_cmd"] = ProductDataRequestCommand(self._address)
         self._handlers["engine_version_cmd"] = EngineVersionRequest(self._address)
+        self._managers[STATUS_COMMAND] = StatusManager(self._address)
 
     def _subscribe_to_handelers_and_managers(self):
         """Subscribe groups and events to handlers and managers."""

--- a/pyinsteon/device_types/device_commands.py
+++ b/pyinsteon/device_types/device_commands.py
@@ -13,9 +13,6 @@ ON_HEARTBEAT_INBOUND = "on_heartbeat_inbound"
 OFF_HEARTBEAT_INBOUND = "off_heartbeat_inbound"
 
 STATUS_COMMAND = "status_command"
-STATUS_COMMAND_HUB = "status_command_hub"
-STATUS_COMMAND_FAN = "status_command_fan"
-STATUS_COMMAND_LOAD = "status_command_load"
 
 ON_COMMAND = "on_command"
 OFF_COMMAND = "off_command"
@@ -29,7 +26,6 @@ EXTENDED_SET_COMMAND = "extended_set"
 EXTENDED_GET_RESPONSE = "extended_get_response"
 
 SET_LEDS_COMMAND = "set_leds"
-GET_LEDS_COMMAND = "get_leds"
 TRIGGER_SCENE_ON_COMMAND = "trigger_scene_on"
 TRIGGER_SCENE_OFF_COMMAND = "trigger_scene_off"
 

--- a/pyinsteon/device_types/dimmable_lighting_control.py
+++ b/pyinsteon/device_types/dimmable_lighting_control.py
@@ -1,4 +1,5 @@
 """Dimmable Lighting Control Devices (CATEGORY 0x01)."""
+
 import asyncio
 from collections.abc import Iterable
 from functools import partial
@@ -68,14 +69,11 @@ from ..groups.on_level import OnLevel
 from ..groups.on_off import OnOff
 from ..handlers.from_device.manual_change import ManualChangeInbound
 from ..handlers.to_device.group_off import GroupOffCommand
-from ..handlers.to_device.group_on import GroupOnCommand
 from ..handlers.to_device.set_leds import SetLedsCommandHandler
-from ..handlers.to_device.status_request import StatusRequestCommand
 from ..handlers.to_device.trigger_scene_off import TriggerSceneOffCommandHandler
 from ..handlers.to_device.trigger_scene_on import TriggerSceneOnCommandHandler
 from ..utils import bit_is_set, multiple_status, set_bit, set_fan_speed
 from .device_commands import (
-    GET_LEDS_COMMAND,
     MANUAL_CHANGE,
     OFF_COMMAND,
     OFF_FAST_COMMAND,
@@ -83,7 +81,6 @@ from .device_commands import (
     ON_FAST_COMMAND,
     SET_LEDS_COMMAND,
     STATUS_COMMAND,
-    STATUS_COMMAND_FAN,
 )
 from .i3_base import I3VariableResponderBase
 from .variable_controller_base import ON_LEVEL_MANAGER
@@ -96,9 +93,6 @@ class DimmableLightingControl(VariableResponderBase):
     def _register_handlers_and_managers(self):
         """Register command handlers and managers."""
         super()._register_handlers_and_managers()
-        self._handlers[STATUS_COMMAND] = StatusRequestCommand(
-            self._address, status_type=2
-        )
         for group, group_prop in self._groups.items():
             if isinstance(group_prop, OnLevel):
                 self._handlers[group][MANUAL_CHANGE] = ManualChangeInbound(
@@ -108,13 +102,15 @@ class DimmableLightingControl(VariableResponderBase):
     def _subscribe_to_handelers_and_managers(self):
         """Subscribe methods to handlers and managers."""
         super()._subscribe_to_handelers_and_managers()
+        self._managers[STATUS_COMMAND].remove_status_type(0)
+        self._managers[STATUS_COMMAND].add_status_type(2, self._handle_status)
         for group, group_prop in self._groups.items():
             if isinstance(group_prop, OnLevel):
                 self._handlers[group][MANUAL_CHANGE].subscribe(
                     self._async_on_manual_change
                 )
 
-    async def _async_on_manual_change(self):
+    async def _async_on_manual_change(self, group=None):
         """Respond to a manual change of the device."""
         await self.async_status()
 
@@ -219,7 +215,7 @@ class DimmableLightingControl_OutletLinc(DimmableLightingControl):
 
     def __init__(self, address, cat, subcat, firmware=0, description="", model=""):
         """Init the DimmableLightingControl_OutletLinc class."""
-        buttons = {1: DIMMABLE_OUTLET}
+        buttons = {1: (DIMMABLE_OUTLET, 0)}
         super().__init__(
             address,
             cat,
@@ -273,7 +269,7 @@ class DimmableLightingControl_FanLinc(DimmableLightingControl):
 
     def __init__(self, address, cat, subcat, firmware=0, description="", model=""):
         """Init the DimmableLightingControl_FanLinc class."""
-        buttons = {1: DIMMABLE_LIGHT, 2: DIMMABLE_FAN}
+        buttons = {1: (DIMMABLE_LIGHT, 0), 2: (DIMMABLE_FAN, 3)}
         super().__init__(
             address,
             cat,
@@ -346,42 +342,9 @@ class DimmableLightingControl_FanLinc(DimmableLightingControl):
         command = OFF_FAST_COMMAND if fast else OFF_COMMAND
         return await self._handlers[group][command].async_send()
 
-    async def async_status(self):
-        """Request the status fo the light and the fan."""
-        light_status = await super().async_status()
-        fan_status = await self.async_fan_status()
-        if light_status == fan_status == ResponseStatus.SUCCESS:
-            return ResponseStatus.SUCCESS
-        if ResponseStatus.DIRECT_NAK_PRE_NAK in (light_status, fan_status):
-            return ResponseStatus.DIRECT_NAK_PRE_NAK
-        return ResponseStatus.FAILURE
-
-    async def async_light_status(self):
-        """Request the status of the light."""
-        return await super().async_status()
-
-    def fan_status(self):
-        """Request the status of the fan."""
-        self._handlers[STATUS_COMMAND_FAN].send()
-
-    async def async_fan_status(self):
-        """Request the status of the fan.
-
-        Returns a ResponseStatus value
-            FAILURE: Device did not acknowledge the message
-            SUCCESS: Device acknowledged the message
-            UNCLEAR: Device received the message but did not confirm the action
-
-        """
-        return await self._handlers[STATUS_COMMAND_FAN].async_send()
-
-    def _register_handlers_and_managers(self):
-        super()._register_handlers_and_managers()
-        self._handlers[STATUS_COMMAND_FAN] = StatusRequestCommand(self._address, 3)
-
     def _subscribe_to_handelers_and_managers(self):
         super()._subscribe_to_handelers_and_managers()
-        self._handlers[STATUS_COMMAND_FAN].subscribe(self._handle_fan_status)
+        self._managers[STATUS_COMMAND].add_status_type(3, self._handle_fan_status)
 
     def _register_op_flags_and_props(self):
         super()._register_op_flags_and_props()
@@ -478,17 +441,6 @@ class DimmableLightingControl_KeypadLinc(DimmableLightingControl):
         """Trigger an All-Link group off."""
         cmd = TriggerSceneOffCommandHandler(self._address, group)
         return await cmd.async_send(fast)
-
-    async def async_status(self):
-        """Check the status of the device."""
-        retries = 5
-        status = ResponseStatus.UNSENT
-        while retries and status != ResponseStatus.SUCCESS:
-            status0 = await super().async_status()
-            status1 = await self._handlers[GET_LEDS_COMMAND].async_send()
-            status = multiple_status(status0, status1)
-            retries -= 1
-        return status
 
     def set_radio_buttons(self, buttons: Iterable):
         """Set a group of buttons to act as radio buttons.
@@ -636,25 +588,29 @@ class DimmableLightingControl_KeypadLinc(DimmableLightingControl):
     def _register_handlers_and_managers(self):
         super()._register_handlers_and_managers()
         self._handlers[SET_LEDS_COMMAND] = SetLedsCommandHandler(address=self.address)
-        self._handlers[GET_LEDS_COMMAND] = StatusRequestCommand(
-            self._address, status_type=1
-        )
 
     def _register_groups(self):
         for button in self._buttons:
-            name = self._buttons[button]
+            name = self._buttons[button][0]
+            status_type = self._buttons[button][1]
             if button == 1:
                 self._groups[button] = OnLevel(
-                    name=name, address=self._address, group=button
+                    name=name,
+                    address=self._address,
+                    group=button,
+                    status_type=status_type,
                 )
             else:
                 self._groups[button] = OnOff(
-                    name=name, address=self._address, group=button
+                    name=name,
+                    address=self._address,
+                    group=button,
+                    status_type=status_type,
                 )
 
     def _subscribe_to_handelers_and_managers(self):
         super()._subscribe_to_handelers_and_managers()
-        self._handlers[GET_LEDS_COMMAND].subscribe(self._led_status)
+        self._managers[STATUS_COMMAND].add_status_type(1, self._led_status)
         for group in self._buttons:
             if group != 1:
                 led_method = partial(self._async_led_follow_check, group=group)
@@ -790,11 +746,11 @@ class DimmableLightingControl_KeypadLinc_6(DimmableLightingControl_KeypadLinc):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the DimmableLightingControl_KeypadLinc_6 class."""
         buttons = {
-            1: DIMMABLE_LIGHT_MAIN,
-            3: ON_OFF_SWITCH_A,
-            4: ON_OFF_SWITCH_B,
-            5: ON_OFF_SWITCH_C,
-            6: ON_OFF_SWITCH_D,
+            1: (DIMMABLE_LIGHT_MAIN, 0),
+            3: (ON_OFF_SWITCH_A, 1),
+            4: (ON_OFF_SWITCH_B, 1),
+            5: (ON_OFF_SWITCH_C, 1),
+            6: (ON_OFF_SWITCH_D, 1),
         }
         super().__init__(
             address=address,
@@ -813,14 +769,14 @@ class DimmableLightingControl_KeypadLinc_8(DimmableLightingControl_KeypadLinc):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the DimmableLightingControl_KeypadLinc_6 class."""
         buttons = {
-            1: DIMMABLE_LIGHT_MAIN,
-            2: ON_OFF_SWITCH_B,
-            3: ON_OFF_SWITCH_C,
-            4: ON_OFF_SWITCH_D,
-            5: ON_OFF_SWITCH_E,
-            6: ON_OFF_SWITCH_F,
-            7: ON_OFF_SWITCH_G,
-            8: ON_OFF_SWITCH_H,
+            1: (DIMMABLE_LIGHT_MAIN, 0),
+            2: (ON_OFF_SWITCH_B, 1),
+            3: (ON_OFF_SWITCH_C, 1),
+            4: (ON_OFF_SWITCH_D, 1),
+            5: (ON_OFF_SWITCH_E, 1),
+            6: (ON_OFF_SWITCH_F, 1),
+            7: (ON_OFF_SWITCH_G, 1),
+            8: (ON_OFF_SWITCH_H, 1),
         }
         super().__init__(
             address=address,
@@ -836,23 +792,18 @@ class DimmableLightingControl_KeypadLinc_8(DimmableLightingControl_KeypadLinc):
 class DimmableLightingControl_Dial(I3VariableResponderBase):
     """Dimmable i3 Dial."""
 
-    def _register_handlers_and_managers(self):
-        """Register command handlers and managers."""
-        super()._register_handlers_and_managers()
-        self._handlers[STATUS_COMMAND] = StatusRequestCommand(
-            self._address, status_type=2
-        )
-
     def _subscribe_to_handelers_and_managers(self):
         """Subscribe methods to handlers and managers."""
         super()._subscribe_to_handelers_and_managers()
+        self._managers[STATUS_COMMAND].remove_status_type(0)
+        self._managers[STATUS_COMMAND].add_status_type(2, self._handle_status)
         for group, group_prop in self._groups.items():
             if isinstance(group_prop, OnLevel):
                 self._handlers[group][MANUAL_CHANGE].subscribe(
                     self._async_on_manual_change
                 )
 
-    async def _async_on_manual_change(self):
+    async def _async_on_manual_change(self, group=None):
         """Respond to a manual change of the device."""
         await self.async_status()
 
@@ -880,10 +831,10 @@ class DimmableLightingControl_I3_KeypadLinc_4(I3VariableResponderBase):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the DimmableLightingControl_I3_KeypadLink_4 class."""
         buttons = {
-            1: ON_OFF_SWITCH_A,
-            2: ON_OFF_SWITCH_B,
-            3: ON_OFF_SWITCH_C,
-            4: ON_OFF_SWITCH_D,
+            1: (ON_OFF_SWITCH_A, 1),
+            2: (ON_OFF_SWITCH_B, 1),
+            3: (ON_OFF_SWITCH_C, 1),
+            4: (ON_OFF_SWITCH_D, 1),
         }
         super().__init__(
             address=address,
@@ -977,22 +928,6 @@ class DimmableLightingControl_I3_KeypadLinc_4(I3VariableResponderBase):
         """Trigger an All-Link group off."""
         cmd = TriggerSceneOffCommandHandler(self._address, group)
         return await cmd.async_send(fast)
-
-    async def async_status(self):
-        """Check the status of the device."""
-        retries = 5
-        status = ResponseStatus.UNSENT
-        while retries and status != ResponseStatus.SUCCESS:
-            status0 = await super().async_status()
-            status1 = await self._handlers[GET_LEDS_COMMAND].async_send()
-            status = multiple_status(status0, status1)
-            retries -= 1
-        return status
-
-    async def async_group_on(self, group: int) -> ResponseStatus:
-        """Trigger a group on."""
-        cmd = GroupOnCommand(address=self._address)
-        return await cmd.async_send(group=group)
 
     async def async_group_off(self, group: int) -> ResponseStatus:
         """Trigger a group off."""
@@ -1205,9 +1140,6 @@ class DimmableLightingControl_I3_KeypadLinc_4(I3VariableResponderBase):
     def _register_handlers_and_managers(self):
         super()._register_handlers_and_managers()
         self._handlers[SET_LEDS_COMMAND] = SetLedsCommandHandler(address=self.address)
-        self._handlers[GET_LEDS_COMMAND] = StatusRequestCommand(
-            self._address, status_type=1
-        )
         self._add_ext_prop_write_manager(
             {3: self._operating_flags[TRIGGER_GROUP_MASK]}, 0x0C, 0x00, 0x00
         )
@@ -1215,7 +1147,7 @@ class DimmableLightingControl_I3_KeypadLinc_4(I3VariableResponderBase):
     def _subscribe_to_handelers_and_managers(self):
         # Not running super due to the LOAD_BUTTON_NUMBER config property
         super()._subscribe_to_handelers_and_managers()
-        self._handlers[GET_LEDS_COMMAND].subscribe(self._async_handle_led_status)
+        self._managers[STATUS_COMMAND].add_status_type(1, self._async_handle_led_status)
         for group in self._buttons:
             led_method = partial(self._async_led_follow_check, group=group)
             self._managers[group][ON_LEVEL_MANAGER].subscribe(

--- a/pyinsteon/device_types/general_controller.py
+++ b/pyinsteon/device_types/general_controller.py
@@ -1,4 +1,5 @@
 """General controller devices (cat: 0x00)."""
+
 from ..aldb.no_aldb import NoALDB
 from ..config import (
     GROUPED_ON,
@@ -8,7 +9,6 @@ from ..config import (
     SEND_ON_ONLY,
     STAY_AWAKE_ON,
 )
-from ..constants import ResponseStatus
 from ..groups import (
     ON_OFF_SWITCH_A,
     ON_OFF_SWITCH_B,
@@ -40,12 +40,12 @@ class GeneralController_ControlLinc(VariableControllerBase):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the GeneralController_ControlLinc class."""
         buttons = {
-            1: ON_OFF_SWITCH_A,
-            2: ON_OFF_SWITCH_B,
-            3: ON_OFF_SWITCH_C,
-            4: ON_OFF_SWITCH_D,
-            5: ON_OFF_SWITCH_E,
-            6: ON_OFF_SWITCH_F,
+            1: (ON_OFF_SWITCH_A, None),
+            2: (ON_OFF_SWITCH_B, None),
+            3: (ON_OFF_SWITCH_C, None),
+            4: (ON_OFF_SWITCH_D, None),
+            5: (ON_OFF_SWITCH_E, None),
+            6: (ON_OFF_SWITCH_F, None),
         }
         super().__init__(
             address, cat, subcat, firmware, description, model, buttons=buttons
@@ -58,12 +58,12 @@ class GeneralController_RemoteLinc(BatteryDeviceBase, VariableControllerBase):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the GeneralController_RemoteLinc class."""
         buttons = {
-            1: ON_OFF_SWITCH_A,
-            2: ON_OFF_SWITCH_B,
-            3: ON_OFF_SWITCH_C,
-            4: ON_OFF_SWITCH_D,
-            5: ON_OFF_SWITCH_E,
-            6: ON_OFF_SWITCH_F,
+            1: (ON_OFF_SWITCH_A, None),
+            2: (ON_OFF_SWITCH_B, None),
+            3: (ON_OFF_SWITCH_C, None),
+            4: (ON_OFF_SWITCH_D, None),
+            5: (ON_OFF_SWITCH_E, None),
+            6: (ON_OFF_SWITCH_F, None),
         }
         super().__init__(
             address, cat, subcat, firmware, description, model, buttons=buttons
@@ -93,10 +93,6 @@ class GeneralController_MiniRemoteBase(BatteryDeviceBase, VariableControllerBase
         )
         self._database_delta = 0
 
-    async def async_status(self, group=0):
-        """Return success always."""
-        return ResponseStatus.SUCCESS
-
     def _register_op_flags_and_props(self):
         super()._register_op_flags_and_props()
         self._add_operating_flag(PROGRAM_LOCK_ON, 0, 0, 0, 1)
@@ -112,7 +108,7 @@ class GeneralController_MiniRemote_Switch(GeneralController_MiniRemoteBase):
 
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the GeneralController_MiniRemote_Switch class."""
-        buttons = {1: ON_OFF_SWITCH_A, 2: ON_OFF_SWITCH_B}
+        buttons = {1: (ON_OFF_SWITCH_A, None), 2: (ON_OFF_SWITCH_B, None)}
         super().__init__(
             address, cat, subcat, firmware, description, model, buttons=buttons
         )
@@ -124,10 +120,10 @@ class GeneralController_MiniRemote_4(GeneralController_MiniRemoteBase):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the GeneralController_MiniRemote_4 class."""
         buttons = {
-            1: ON_OFF_SWITCH_A,
-            2: ON_OFF_SWITCH_B,
-            3: ON_OFF_SWITCH_C,
-            4: ON_OFF_SWITCH_D,
+            1: (ON_OFF_SWITCH_A, None),
+            2: (ON_OFF_SWITCH_B, None),
+            3: (ON_OFF_SWITCH_C, None),
+            4: (ON_OFF_SWITCH_D, None),
         }
         super().__init__(
             address, cat, subcat, firmware, description, model, buttons=buttons
@@ -140,14 +136,14 @@ class GeneralController_MiniRemote_8(GeneralController_MiniRemoteBase):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the GeneralController_MiniRemote_8 class."""
         buttons = {
-            1: ON_OFF_SWITCH_B,
-            2: ON_OFF_SWITCH_A,
-            3: ON_OFF_SWITCH_D,
-            4: ON_OFF_SWITCH_C,
-            5: ON_OFF_SWITCH_F,
-            6: ON_OFF_SWITCH_E,
-            7: ON_OFF_SWITCH_H,
-            8: ON_OFF_SWITCH_G,
+            1: (ON_OFF_SWITCH_B, None),
+            2: (ON_OFF_SWITCH_A, None),
+            3: (ON_OFF_SWITCH_D, None),
+            4: (ON_OFF_SWITCH_C, None),
+            5: (ON_OFF_SWITCH_F, None),
+            6: (ON_OFF_SWITCH_E, None),
+            7: (ON_OFF_SWITCH_H, None),
+            8: (ON_OFF_SWITCH_G, None),
         }
         super().__init__(
             address, cat, subcat, firmware, description, model, buttons=buttons

--- a/pyinsteon/device_types/open_close_responder_base.py
+++ b/pyinsteon/device_types/open_close_responder_base.py
@@ -1,16 +1,10 @@
 """Dimmable Lighting Control Devices (CATEGORY 0x01)."""
+
 from ..handlers.to_device.off import OffCommand
 from ..handlers.to_device.off_fast import OffFastCommand
 from ..handlers.to_device.on_fast import OnFastCommand
 from ..handlers.to_device.on_level import OnLevelCommand
-from ..handlers.to_device.status_request import StatusRequestCommand
-from .device_commands import (
-    OFF_COMMAND,
-    OFF_FAST_COMMAND,
-    ON_COMMAND,
-    ON_FAST_COMMAND,
-    STATUS_COMMAND,
-)
+from .device_commands import OFF_COMMAND, OFF_FAST_COMMAND, ON_COMMAND, ON_FAST_COMMAND
 from .open_close_controller_base import OpenCloseControllerBase
 
 
@@ -77,14 +71,8 @@ class OpenCloseResponderBase(OpenCloseControllerBase):
         command = OFF_FAST_COMMAND if fast else OFF_COMMAND
         return await self._handlers[group][command].async_send()
 
-    # pylint: disable=arguments-differ
-    async def async_status(self):
-        """Get the status of the device state."""
-        return await self._handlers[STATUS_COMMAND].async_send()
-
     def _register_handlers_and_managers(self):
         super()._register_handlers_and_managers()
-        self._handlers[STATUS_COMMAND] = StatusRequestCommand(self._address)
         group = 1
         if self._handlers.get(group) is None:
             self._handlers[group] = {}

--- a/pyinsteon/device_types/security_health_safety.py
+++ b/pyinsteon/device_types/security_health_safety.py
@@ -1,4 +1,5 @@
 """Security, Heath and Safety device types."""
+
 from ..config import (
     AMBIENT_LIGHT_INTENSITY,
     BATTERY_LEVEL,
@@ -94,7 +95,7 @@ class SecurityHealthSafety_DoorSensor(BatteryDeviceBase, OnOffControllerBase):
 
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the SecurityHealthSafety_DoorSensor class."""
-        buttons = {1: DOOR_SENSOR}
+        buttons = {1: (DOOR_SENSOR, None)}
         super().__init__(
             address=address,
             cat=cat,
@@ -225,7 +226,7 @@ class SecurityHealthSafety_MotionSensor(BatteryDeviceBase, OnOffControllerBase):
 
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the SecurityHealthSafety_DoorSensor class."""
-        buttons = {1: MOTION_SENSOR}
+        buttons = {1: (MOTION_SENSOR, None)}
         self._light_manager = OnLevelManager(address, self.LIGHT_GROUP)
         self._low_battery_manager = LowBatteryManager(address, self.LOW_BATTERY_GROUP)
         super().__init__(

--- a/pyinsteon/device_types/variable_controller_base.py
+++ b/pyinsteon/device_types/variable_controller_base.py
@@ -4,8 +4,8 @@ from ..default_link import DefaultLink
 from ..events import OFF_EVENT, OFF_FAST_EVENT, ON_EVENT, ON_FAST_EVENT, Event
 from ..groups import DIMMABLE_LIGHT
 from ..groups.on_level import OnLevel
-from ..handlers.to_device.status_request import StatusRequestCommand
 from ..managers.on_level_manager import OnLevelManager
+from ..managers.status_manager import StatusManager
 from .device_base import Device
 from .device_commands import STATUS_COMMAND
 
@@ -26,20 +26,8 @@ class VariableControllerBase(Device):
         buttons=None,
     ):
         """Init the VariableControllerBase class."""
-        self._buttons = {1: DIMMABLE_LIGHT} if buttons is None else buttons
+        self._buttons = {1: (DIMMABLE_LIGHT, 0)} if buttons is None else buttons
         super().__init__(address, cat, subcat, firmware, description, model)
-
-    # pylint: disable=arguments-differ
-    async def async_status(self):
-        """Request the status of the device.
-
-        Returns a ResponseStatus value
-            FAILURE: Device did not acknowledge the message
-            SUCCESS: Device acknowledged the message
-            UNCLEAR: Device received the message but did not confirm the action
-
-        """
-        return await self._handlers[STATUS_COMMAND].async_send()
 
     def _register_default_links(self):
         """Register default links.
@@ -64,7 +52,7 @@ class VariableControllerBase(Device):
 
     def _register_handlers_and_managers(self):
         super()._register_handlers_and_managers()
-        self._handlers[STATUS_COMMAND] = StatusRequestCommand(self._address)
+        self._managers[STATUS_COMMAND] = StatusManager(self._address)
         for group in self._buttons:
             if self._managers.get(group) is None:
                 self._managers[group] = {}
@@ -75,8 +63,11 @@ class VariableControllerBase(Device):
     def _register_groups(self):
         super()._register_groups()
         for group in self._buttons:
-            name = self._buttons[group]
-            self._groups[group] = OnLevel(name=name, address=self._address, group=group)
+            name = self._buttons[group][0]
+            status_type = self._buttons[group][1]
+            self._groups[group] = OnLevel(
+                name=name, address=self._address, group=group, status_type=status_type
+            )
 
     def _register_events(self):
         super()._register_events()
@@ -99,7 +90,9 @@ class VariableControllerBase(Device):
 
     def _subscribe_to_handelers_and_managers(self):
         super()._subscribe_to_handelers_and_managers()
-        self._handlers[STATUS_COMMAND].subscribe(self._handle_status)
+        self._managers[STATUS_COMMAND].add_status_type(
+            status_type=0, callback_function=self._handle_status
+        )
         for group in self._buttons:
             state = self._groups[group]
             self._managers[group][ON_LEVEL_MANAGER].subscribe(state.set_value)

--- a/pyinsteon/device_types/variable_responder_base.py
+++ b/pyinsteon/device_types/variable_responder_base.py
@@ -1,9 +1,9 @@
 """Dimmable Lighting Control Devices (CATEGORY 0x01)."""
+
 from ..handlers.to_device.off import OffCommand
 from ..handlers.to_device.off_fast import OffFastCommand
 from ..handlers.to_device.on_fast import OnFastCommand
 from ..handlers.to_device.on_level import OnLevelCommand
-from ..handlers.to_device.status_request import StatusRequestCommand
 from .device_commands import (
     OFF_COMMAND,
     OFF_FAST_COMMAND,
@@ -77,13 +77,13 @@ class VariableResponderBase(VariableControllerBase):
         command = OFF_FAST_COMMAND if fast else OFF_COMMAND
         return await self._handlers[group][command].async_send()
 
-    async def async_status(self):
-        """Get the status of the device state."""
-        return await self._handlers[STATUS_COMMAND].async_send()
+    async def async_status(self, group=None):
+        """Get the device status."""
+        status_type = self._groups[group].status_type if group is not None else None
+        return await self._managers[STATUS_COMMAND].async_status(status_type)
 
     def _register_handlers_and_managers(self):
         super()._register_handlers_and_managers()
-        self._handlers[STATUS_COMMAND] = StatusRequestCommand(self._address)
         for group in self._buttons:
             if self._handlers.get(group) is None:
                 self._handlers[group] = {}

--- a/pyinsteon/groups/fan.py
+++ b/pyinsteon/groups/fan.py
@@ -1,4 +1,5 @@
 """Fan On Level state."""
+
 from ..address import Address
 from ..constants import FanSpeed, FanSpeedRange
 from .group_base import GroupBase
@@ -8,10 +9,17 @@ class FanOnLevel(GroupBase):
     """On / Off state."""
 
     def __init__(
-        self, name: str, address: Address, group: int = 0, default: FanSpeed = None
+        self,
+        name: str,
+        address: Address,
+        group: int = 0,
+        default: FanSpeed = None,
+        status_type: int = 0,
     ):
         """Init the FanOnLevel class."""
-        super().__init__(name, address, group, default, value_type=FanSpeed)
+        super().__init__(
+            name, address, group, default, value_type=FanSpeed, status_type=status_type
+        )
         self._is_dimmable = True
 
     # pylint: disable=arguments-differ

--- a/pyinsteon/groups/group_base.py
+++ b/pyinsteon/groups/group_base.py
@@ -12,7 +12,13 @@ class GroupBase(SubscriberBase):
     __meta__ = ABC
 
     def __init__(
-        self, name: str, address: Address, group=0, default=None, value_type: type = int
+        self,
+        name: str,
+        address: Address,
+        group=0,
+        default=None,
+        value_type: type = int,
+        status_type: int = 0,
     ):
         """Init the StateBase class."""
         self._address = address
@@ -23,6 +29,7 @@ class GroupBase(SubscriberBase):
         self._value = int(default) if default is not None else None
         self._type = value_type
         self._is_dimmable: bool = False
+        self._status_type = status_type
 
     @property
     def is_dimmable(self) -> bool:
@@ -71,6 +78,11 @@ class GroupBase(SubscriberBase):
             value=self._value,
             group=self._group,
         )
+
+    @property
+    def status_type(self):
+        """Return the status type to get the group state."""
+        return self._status_type
 
     @abstractmethod
     def set_value(self, **kwargs):

--- a/pyinsteon/groups/on_level.py
+++ b/pyinsteon/groups/on_level.py
@@ -1,4 +1,5 @@
 """On Leve state."""
+
 import logging
 
 from ..address import Address
@@ -11,10 +12,17 @@ class OnLevel(GroupBase):
     """Variable On Level state."""
 
     def __init__(
-        self, name: str, address: Address, group: int = 0, default: int = None
+        self,
+        name: str,
+        address: Address,
+        group: int = 0,
+        default: int = None,
+        status_type: int = 0,
     ):
         """Init the OnLevel class."""
-        super().__init__(name, address, group, default, value_type=int)
+        super().__init__(
+            name, address, group, default, value_type=int, status_type=status_type
+        )
         self._is_dimmable: bool = True
 
     @property

--- a/pyinsteon/groups/on_off.py
+++ b/pyinsteon/groups/on_off.py
@@ -1,4 +1,5 @@
 """On / Off state."""
+
 from ..address import Address
 from .group_base import GroupBase
 
@@ -7,10 +8,17 @@ class OnOff(GroupBase):
     """On / Off state."""
 
     def __init__(
-        self, name: str, address: Address, group: int = 0, default: int = None
+        self,
+        name: str,
+        address: Address,
+        group: int = 0,
+        default: int = None,
+        status_type: int = 0,
     ):
         """Init the OnLevel class."""
-        super().__init__(name, address, group, default, value_type=int)
+        super().__init__(
+            name, address, group, default, value_type=int, status_type=status_type
+        )
 
     # pylint: disable=arguments-differ
     def set_value(self, on_level):

--- a/pyinsteon/groups/open_close.py
+++ b/pyinsteon/groups/open_close.py
@@ -1,4 +1,5 @@
 """Open / Close sensor groups."""
+
 from ..address import Address
 from .group_base import GroupBase
 
@@ -7,10 +8,17 @@ class NormallyOpen(GroupBase):
     """Normally open sensor state."""
 
     def __init__(
-        self, name: str, address: Address, group: int = 0, default: int = None
+        self,
+        name: str,
+        address: Address,
+        group: int = 0,
+        default: int = None,
+        status_type: int = 0,
     ):
         """Init the OnLevel class."""
-        super().__init__(name, address, group, default, value_type=int)
+        super().__init__(
+            name, address, group, default, value_type=int, status_type=status_type
+        )
 
     # pylint: disable=arguments-differ
     def set_value(self, on_level):
@@ -23,10 +31,17 @@ class NormallyClosed(GroupBase):
     """Normally closed sensor state."""
 
     def __init__(
-        self, name: str, address: Address, group: int = 0, default: int = None
+        self,
+        name: str,
+        address: Address,
+        group: int = 0,
+        default: int = None,
+        status_type: int = 0,
     ):
-        """Init the OnLevel class."""
-        super().__init__(name, address, group, default, value_type=int)
+        """Init the NormallyClosed class."""
+        super().__init__(
+            name, address, group, default, value_type=int, status_type=status_type
+        )
 
     # pylint: disable=arguments-differ
     def set_value(self, on_level):

--- a/pyinsteon/groups/thermostat.py
+++ b/pyinsteon/groups/thermostat.py
@@ -1,4 +1,5 @@
 """Temperature state."""
+
 from ..address import Address
 from ..constants import ThermostatMode
 from .group_base import GroupBase
@@ -13,9 +14,12 @@ class Temperature(GroupBase):
         address: Address,
         group: int = 0,
         default: float = None,
+        status_type: int = 0,
     ):
         """Init the Temperature class."""
-        super().__init__(name, address, group, default, value_type=float)
+        super().__init__(
+            name, address, group, default, value_type=float, status_type=status_type
+        )
         self._is_dimmable = True
 
     # pylint: disable=arguments-differ

--- a/pyinsteon/groups/wet_dry.py
+++ b/pyinsteon/groups/wet_dry.py
@@ -1,4 +1,5 @@
 """Wet / Dry state."""
+
 from ..address import Address
 from .group_base import GroupBase
 
@@ -7,10 +8,17 @@ class Dry(GroupBase):
     """Dry state."""
 
     def __init__(
-        self, name: str, address: Address, group: int = 0, default: bool = None
+        self,
+        name: str,
+        address: Address,
+        group: int = 0,
+        default: bool = None,
+        status_type: int = 0,
     ):
         """Init the WetDry class."""
-        super().__init__(name, address, group, default, value_type=bool)
+        super().__init__(
+            name, address, group, default, value_type=bool, status_type=status_type
+        )
 
     # pylint: disable=arguments-differ
     def set_value(self, dry):

--- a/pyinsteon/handlers/to_device/status_request.py
+++ b/pyinsteon/handlers/to_device/status_request.py
@@ -1,4 +1,5 @@
 """Manage outbound ON command to a device."""
+
 import asyncio
 
 from .. import ack_handler, status_handler
@@ -13,9 +14,14 @@ class StatusRequestCommand(DirectCommandHandlerBase):
 
     def __init__(self, address, status_type: int = 0):
         """Init the OnLevelCommand class."""
-        super().__init__(topic=STATUS_REQUEST, address=address, group=None)
         self._status_type = status_type
+        super().__init__(topic=STATUS_REQUEST, address=address, group=None)
         self._subscriber_topic = f"handler.{self._address.id}.{self._status_type}.{STATUS_REQUEST}.{str(MessageFlagType.DIRECT).lower()}"
+
+    @property
+    def status_type(self):
+        """Return the status type."""
+        return self._status_type
 
     # pylint: disable=arguments-differ, useless-super-delegation
     async def async_send(self):

--- a/pyinsteon/managers/status_manager.py
+++ b/pyinsteon/managers/status_manager.py
@@ -82,8 +82,8 @@ class StatusManager:
             [status_type] if status_type is not None else self._status_cmds.keys()
         )
         async with self._run_lock:
-            for status_type in status_types:
-                result = await self._async_status(self._status_cmds[status_type])
+            for curr_status_type in status_types:
+                result = await self._async_status(self._status_cmds[curr_status_type])
                 results.append(result)
             self._call_waiting = False
 

--- a/pyinsteon/managers/status_manager.py
+++ b/pyinsteon/managers/status_manager.py
@@ -1,0 +1,102 @@
+"""Manage status requests.
+
+Status requests should not run more often than necessary due to the nature of linking the status message response to the original request.
+If status messages overlap, the response can be very difficult to associate to the original request. This is especially important for
+devices that have multiple status messages.
+
+Logic:
+first call always happens when requested
+second call happens
+    if
+        No other call is in progress then run
+    else
+        if
+            Another call is in queue then cancel
+        else
+            Wait until the first call is done then run
+
+"""
+
+from asyncio import Lock
+from logging import DEBUG, getLogger
+from typing import Callable, Dict, Union
+
+from ..address import Address
+from ..constants import ResponseStatus
+from ..handlers.to_device.status_request import StatusRequestCommand
+from ..utils import multiple_status
+
+_LOGGER = getLogger(__name__)
+_LOGGER.setLevel(DEBUG)
+
+
+class StatusManager:
+    """Status manager."""
+
+    def __init__(self, address: Address):
+        """Init the StatusManager class."""
+        self._address = Address(address)
+        self._status_cmds: Dict[int, StatusRequestCommand] = {}
+        self._callbacks: Dict[int, Callable] = {}
+        self._call_waiting: bool = False
+        self._run_lock = Lock()
+
+    def add_status_type(self, status_type: int, callback_function: Callable):
+        """Add a status request type."""
+        self.remove_status_type(status_type=status_type)
+
+        status_cmd = StatusRequestCommand(self._address, status_type)
+        status_cmd.subscribe(callback_function)
+        self._status_cmds[status_type] = status_cmd
+        self._callbacks[status_type] = callback_function
+
+    def remove_status_type(self, status_type: int):
+        """Remove a status request type and unsubscribe to command responses."""
+        status_cmd: StatusRequestCommand = self._status_cmds.get(status_type)
+        if status_cmd:
+            status_cmd.unsubscribe(self._callbacks[status_type])
+            self._callbacks.pop(status_type)
+            self._status_cmds.pop(status_type)
+
+    async def async_status(
+        self, status_type: Union[int, None] = None
+    ) -> ResponseStatus:
+        """Send the status request."""
+        if self._call_waiting:
+            # No need for this call because an existing call is already scheduled
+            _LOGGER.debug("No need to run this status request.")
+            return ResponseStatus.SUCCESS
+
+        if self._run_lock.locked():
+            # This is the second call and needs to wait for the first call to finish
+            # Make sure any subsequent calls know there is already a call waiting
+            _LOGGER.debug(
+                "This status request is waiting for the prior request to finish."
+            )
+            self._call_waiting = True
+
+        results = []
+        if status_type is not None and status_type not in self._status_cmds:
+            status_type = None
+        status_types = (
+            [status_type] if status_type is not None else self._status_cmds.keys()
+        )
+        async with self._run_lock:
+            for status_type in status_types:
+                result = await self._async_status(self._status_cmds[status_type])
+                results.append(result)
+            self._call_waiting = False
+
+        return multiple_status(*results)
+
+    async def _async_status(self, status_cmd: Callable) -> ResponseStatus:
+        """Execute the status command."""
+        retries = 2
+        result = ResponseStatus.UNSENT
+        while retries and result not in [
+            ResponseStatus.SUCCESS,
+            ResponseStatus.DIRECT_NAK_ALDB,
+        ]:
+            result = await status_cmd.async_send()
+            retries -= 1
+        return result

--- a/pyinsteon/managers/thermostat_status_manager.py
+++ b/pyinsteon/managers/thermostat_status_manager.py
@@ -1,4 +1,5 @@
 """Thermostat status manager."""
+
 import asyncio
 from collections import namedtuple
 import logging
@@ -70,7 +71,7 @@ class GetThermostatStatus:
         self._status_listeners = []
         self._set_point_listeners = []
 
-    async def async_status(self):
+    async def async_status(self, group=None):
         """Read the device status."""
         status1 = await self._status()
         status2 = await self._set_point()

--- a/tests/test_managers/test_status_manager.py
+++ b/tests/test_managers/test_status_manager.py
@@ -1,0 +1,122 @@
+"""Test the StatusManager class."""
+
+import asyncio
+from functools import partial
+import unittest
+from unittest.mock import AsyncMock
+
+from pyinsteon.constants import ResponseStatus
+from pyinsteon.managers.status_manager import StatusManager
+from pyinsteon.utils import subscribe_topic, unsubscribe_topic
+
+from .. import set_log_levels
+from ..utils import TopicItem, async_case, random_address, send_topics
+
+
+async def handle_status(handler, db_version, status):
+    """Handle the status call."""
+    await handler(db_version, status)
+
+
+def gen_topic_items(address, status_type, db_version, status):
+    """Generate a set of topics to respond correctly to a status request."""
+    ack_topic = f"ack.{address.id}.status_request.direct"
+    direct_ack_topic = f"{address.id}.any_topic.direct_ack"
+    return [
+        TopicItem(
+            ack_topic,
+            {"cmd1": 0x19, "cmd2": status_type, "user_data": None},
+            0.1,
+        ),
+        TopicItem(
+            direct_ack_topic,
+            {
+                "cmd1": db_version,
+                "cmd2": status,
+                "target": address.id,
+                "user_data": None,
+                "hops_left": 3,
+            },
+            0.5,
+        ),
+    ]
+
+
+def send_status_topics(address, status_type):
+    """Send the ack and direct_ack topics for a status message."""
+    topic_items = gen_topic_items(address, status_type, 0x22, 0x33)
+    send_topics(topic_items=topic_items)
+
+
+class TestStatusManager(unittest.TestCase):
+    """Test the StatusManager class."""
+
+    def setUp(self) -> None:
+        """Set up the test."""
+        set_log_levels(logger="debug", logger_topics=True)
+        subscribe_topic(send_status_topics, "send.status_request.direct")
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        """Unsubscribe to topic."""
+        unsubscribe_topic(send_status_topics, "send.status_request.direct")
+        return super().tearDown()
+
+    @async_case
+    async def test_single_status_call(self):
+        """Test a single status call."""
+        handler = AsyncMock(db_version=None, status=None)
+        address = random_address()
+        status_type = 0
+        status_manager = StatusManager(address=address)
+        status_manager.add_status_type(
+            status_type=status_type,
+            callback_function=partial(handle_status, handler=handler),
+        )
+
+        result = await status_manager.async_status()
+        await asyncio.sleep(0.01)
+        assert result == ResponseStatus.SUCCESS
+        assert handler.call_count == 1
+
+    @async_case
+    async def test_two_status_calls(self):
+        """Test a two status calls."""
+        handler = AsyncMock(db_version=None, status=None)
+        handler_1 = AsyncMock()
+        address = random_address()
+        status_type = 0
+        status_manager = StatusManager(address=address)
+        status_manager.add_status_type(
+            status_type=status_type,
+            callback_function=partial(handle_status, handler=handler),
+        )
+        status_type_1 = 1
+        status_manager.add_status_type(
+            status_type=status_type_1,
+            callback_function=partial(handle_status, handler=handler_1),
+        )
+
+        result = await status_manager.async_status()
+        await asyncio.sleep(1)
+        assert result == ResponseStatus.SUCCESS
+        assert handler.call_count == 1
+        assert handler_1.call_count == 1
+
+    @async_case
+    async def test_overlapping_status_calls(self):
+        """Test overlapping status request calls."""
+        handler = AsyncMock(db_version=None, status=None)
+        address = random_address()
+        status_type = 0
+        status_manager = StatusManager(address=address)
+        status_manager.add_status_type(
+            status_type=status_type,
+            callback_function=partial(handle_status, handler=handler),
+        )
+
+        asyncio.ensure_future(status_manager.async_status())
+        asyncio.ensure_future(status_manager.async_status())
+        await status_manager.async_status()
+        await asyncio.sleep(5)
+        assert handler.call_count == 2


### PR DESCRIPTION
Update the status process to ensure only one status request is occuring at a time. This should prevent multiple status requests from overlapping causing status messages to apply to the wrong status message type.