### PR TITLE
Release 1.6.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.155.1/containers/python-3/.devcontainer/base.Dockerfile
 
-# [Choice] Python version: 3, 3.11, 3.10, 3.9, 3.8
+# [Choice] Python version: 3, 3.12, 3.11, 3.10, 3.9
 ARG VARIANT="3"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
 # ARG INSTALL_NODE="true"
 # ARG NODE_VERSION="lts/*"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,8 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      // Update 'VARIANT' to pick a Python version: 3.8, 3.9, 3.10, 3.11
-      "VARIANT": "3.11"
+      // Update 'VARIANT' to pick a Python version: 3.9, 3.10, 3.11, 3.12
+      "VARIANT": "3.12"
     }
   },
   "runArgs": ["--device=/dev/insteon"],

--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -17,7 +17,7 @@ should be usable for other applications as well.
 Requirements
 ------------
 
--  Python 3.8, 3.9, 3.10 or 3.11
+-  Python 3.9, 3.10 or 3.11, 3.12
 -  Posix or Windows based system
 -  Some form of Insteon PLM or Hub
 -  At least one Insteon device

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ should be usable for other applications as well.
 Requirements
 ------------
 
--  Python 3.8 3.9, 3.10 or 3.11
+-  Python 3.9, 3.10, 3.11 or 3.12
 -  Posix or Windows based system
 -  Some form of Insteon PLM or Hub
 -  At least one Insteon device

--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -43,14 +43,14 @@ stages:
       vmImage: 'ubuntu-latest'
     strategy:
       matrix:
-        Python38:
-          python.version: '3.8'
         Python39:
           python.version: '3.9'
         Python310:
           python.version: '3.10'
         Python311:
           python.version: '3.11'
+        Python312:
+          python.version: '3.12'
     steps:
     - task: UsePythonVersion@0
       inputs:

--- a/pyinsteon/commands.py
+++ b/pyinsteon/commands.py
@@ -1,4 +1,5 @@
 """Collection of topics mapped to commands (cmd1, cmd2)."""
+
 from collections import namedtuple
 import logging
 from typing import Tuple
@@ -48,9 +49,11 @@ from .topics import (
     NIGHT_MODE_ON,
     OFF,
     OFF_AT_RAMP_RATE,
+    OFF_AT_RAMP_RATE_INBOUND,
     OFF_FAST,
     ON,
     ON_AT_RAMP_RATE,
+    ON_AT_RAMP_RATE_INBOUND,
     ON_FAST,
     PEEK,
     PEEK_INTERNAL,
@@ -199,7 +202,7 @@ class Commands:
         """Return if a topic requires a group number."""
         return self._use_group.get(topic)
 
-    def get_topics(self, cmd1, cmd2, flags, userdata=None, send=False) -> str:
+    def get_topics(self, cmd1, cmd2, flags, userdata=None, send=False):
         """Generate a topic from a cmd1, cmd2 and extended flag."""
         found = False
         for topic in self._commands_topic_map.get(cmd1, {}):
@@ -679,6 +682,24 @@ commands.add(
     ud_required=False,
     userdata=None,
     use_group=False,
+)
+commands.add(
+    topic=ON_AT_RAMP_RATE_INBOUND,
+    cmd1=0x34,
+    cmd2=None,
+    ud_allowed=False,
+    ud_required=False,
+    userdata=None,
+    use_group=True,
+)
+commands.add(
+    topic=OFF_AT_RAMP_RATE_INBOUND,
+    cmd1=0x35,
+    cmd2=None,
+    ud_allowed=False,
+    ud_required=False,
+    userdata=None,
+    use_group=True,
 )
 commands.add(
     topic=NIGHT_MODE_ON,

--- a/pyinsteon/device_types/access_control.py
+++ b/pyinsteon/device_types/access_control.py
@@ -1,6 +1,5 @@
 """Access control device types."""
 
-
 from ..events import OFF_EVENT, OFF_FAST_EVENT, ON_EVENT, ON_FAST_EVENT
 from ..groups import ON_OFF_SWITCH
 from .on_off_responder_base import OnOffResponderBase
@@ -25,7 +24,7 @@ class AccessControl_Morningstar(OnOffResponderBase):
         off_fast_event_name=OFF_FAST_EVENT,
     ):
         """Init the OnOffResponderBase class."""
-        buttons = {1: ON_OFF_SWITCH} if buttons is None else buttons
+        buttons = {1: (ON_OFF_SWITCH, 0)} if buttons is None else buttons
         super().__init__(
             address,
             cat,

--- a/pyinsteon/device_types/climate_control.py
+++ b/pyinsteon/device_types/climate_control.py
@@ -1,4 +1,5 @@
 """Thermostat device types."""
+
 from datetime import datetime
 import logging
 
@@ -91,11 +92,6 @@ class ClimateControl_Thermostat(Device):
             model=model,
         )
         self._aldb = ALDB(self._address, mem_addr=0x1FFF)
-
-    # pylint: disable=arguments-differ
-    async def async_status(self, group=None):
-        """Get the status of the device."""
-        return await self._managers[STATUS_COMMAND].async_status()
 
     async def async_set_cool_set_point(self, temperature):
         """Set the cool set point."""

--- a/pyinsteon/device_types/device_base.py
+++ b/pyinsteon/device_types/device_base.py
@@ -11,12 +11,14 @@ from ..config.extended_property import ExtendedProperty
 from ..config.operating_flag import OperatingFlag
 from ..constants import DeviceCategory, EngineVersion, PropertyType, ResponseStatus
 from ..default_link import DefaultLink
+from ..device_types.device_commands import STATUS_COMMAND
 from ..handlers.to_device.engine_version_request import EngineVersionRequest
 from ..handlers.to_device.ping import PingCommand
 from ..handlers.to_device.product_data_request import ProductDataRequestCommand
 from ..managers.get_set_ext_property_manager import GetSetExtendedPropertyManager
 from ..managers.get_set_op_flag_manager import GetSetOperatingFlagsManager
 from ..managers.link_manager.default_links import async_add_default_links
+from ..managers.status_manager import StatusManager
 from ..topics import ENGINE_VERSION
 from ..utils import multiple_status, publish_topic
 
@@ -176,6 +178,7 @@ class Device(ABC):
 
     async def async_status(self, group=None):
         """Get the status of the device."""
+        return ResponseStatus.SUCCESS
 
     async def async_read_config(self, read_aldb: bool = True):
         """Get all configuration settings.
@@ -243,6 +246,7 @@ class Device(ABC):
         """Add all handlers to the device and register listeners."""
         self._handlers["product_data_cmd"] = ProductDataRequestCommand(self._address)
         self._handlers["engine_version_cmd"] = EngineVersionRequest(self._address)
+        self._managers[STATUS_COMMAND] = StatusManager(self._address)
 
     def _subscribe_to_handelers_and_managers(self):
         """Subscribe groups and events to handlers and managers."""

--- a/pyinsteon/device_types/device_commands.py
+++ b/pyinsteon/device_types/device_commands.py
@@ -13,9 +13,6 @@ ON_HEARTBEAT_INBOUND = "on_heartbeat_inbound"
 OFF_HEARTBEAT_INBOUND = "off_heartbeat_inbound"
 
 STATUS_COMMAND = "status_command"
-STATUS_COMMAND_HUB = "status_command_hub"
-STATUS_COMMAND_FAN = "status_command_fan"
-STATUS_COMMAND_LOAD = "status_command_load"
 
 ON_COMMAND = "on_command"
 OFF_COMMAND = "off_command"
@@ -29,7 +26,6 @@ EXTENDED_SET_COMMAND = "extended_set"
 EXTENDED_GET_RESPONSE = "extended_get_response"
 
 SET_LEDS_COMMAND = "set_leds"
-GET_LEDS_COMMAND = "get_leds"
 TRIGGER_SCENE_ON_COMMAND = "trigger_scene_on"
 TRIGGER_SCENE_OFF_COMMAND = "trigger_scene_off"
 

--- a/pyinsteon/device_types/device_commands.py
+++ b/pyinsteon/device_types/device_commands.py
@@ -33,3 +33,5 @@ GET_IM_CONFIG_COMMAND = "get_im_config"
 SET_IM_CONFIG_COMMAND = "set_im_config"
 
 MANUAL_CHANGE = "manual_change"
+ON_AT_RAMP_RATE = "on_at_ramp_rate"
+OFF_AT_RAMP_RATE = "off_at_ramp_rate"

--- a/pyinsteon/device_types/dimmable_lighting_control.py
+++ b/pyinsteon/device_types/dimmable_lighting_control.py
@@ -1,4 +1,5 @@
 """Dimmable Lighting Control Devices (CATEGORY 0x01)."""
+
 import asyncio
 from collections.abc import Iterable
 from functools import partial
@@ -68,14 +69,11 @@ from ..groups.on_level import OnLevel
 from ..groups.on_off import OnOff
 from ..handlers.from_device.manual_change import ManualChangeInbound
 from ..handlers.to_device.group_off import GroupOffCommand
-from ..handlers.to_device.group_on import GroupOnCommand
 from ..handlers.to_device.set_leds import SetLedsCommandHandler
-from ..handlers.to_device.status_request import StatusRequestCommand
 from ..handlers.to_device.trigger_scene_off import TriggerSceneOffCommandHandler
 from ..handlers.to_device.trigger_scene_on import TriggerSceneOnCommandHandler
 from ..utils import bit_is_set, multiple_status, set_bit, set_fan_speed
 from .device_commands import (
-    GET_LEDS_COMMAND,
     MANUAL_CHANGE,
     OFF_COMMAND,
     OFF_FAST_COMMAND,
@@ -83,7 +81,6 @@ from .device_commands import (
     ON_FAST_COMMAND,
     SET_LEDS_COMMAND,
     STATUS_COMMAND,
-    STATUS_COMMAND_FAN,
 )
 from .i3_base import I3VariableResponderBase
 from .variable_controller_base import ON_LEVEL_MANAGER
@@ -96,9 +93,6 @@ class DimmableLightingControl(VariableResponderBase):
     def _register_handlers_and_managers(self):
         """Register command handlers and managers."""
         super()._register_handlers_and_managers()
-        self._handlers[STATUS_COMMAND] = StatusRequestCommand(
-            self._address, status_type=2
-        )
         for group, group_prop in self._groups.items():
             if isinstance(group_prop, OnLevel):
                 self._handlers[group][MANUAL_CHANGE] = ManualChangeInbound(
@@ -108,13 +102,15 @@ class DimmableLightingControl(VariableResponderBase):
     def _subscribe_to_handelers_and_managers(self):
         """Subscribe methods to handlers and managers."""
         super()._subscribe_to_handelers_and_managers()
+        self._managers[STATUS_COMMAND].remove_status_type(0)
+        self._managers[STATUS_COMMAND].add_status_type(2, self._handle_status)
         for group, group_prop in self._groups.items():
             if isinstance(group_prop, OnLevel):
                 self._handlers[group][MANUAL_CHANGE].subscribe(
                     self._async_on_manual_change
                 )
 
-    async def _async_on_manual_change(self):
+    async def _async_on_manual_change(self, group=None):
         """Respond to a manual change of the device."""
         await self.async_status()
 
@@ -219,7 +215,7 @@ class DimmableLightingControl_OutletLinc(DimmableLightingControl):
 
     def __init__(self, address, cat, subcat, firmware=0, description="", model=""):
         """Init the DimmableLightingControl_OutletLinc class."""
-        buttons = {1: DIMMABLE_OUTLET}
+        buttons = {1: (DIMMABLE_OUTLET, 0)}
         super().__init__(
             address,
             cat,
@@ -273,7 +269,7 @@ class DimmableLightingControl_FanLinc(DimmableLightingControl):
 
     def __init__(self, address, cat, subcat, firmware=0, description="", model=""):
         """Init the DimmableLightingControl_FanLinc class."""
-        buttons = {1: DIMMABLE_LIGHT, 2: DIMMABLE_FAN}
+        buttons = {1: (DIMMABLE_LIGHT, 0), 2: (DIMMABLE_FAN, 3)}
         super().__init__(
             address,
             cat,
@@ -346,42 +342,9 @@ class DimmableLightingControl_FanLinc(DimmableLightingControl):
         command = OFF_FAST_COMMAND if fast else OFF_COMMAND
         return await self._handlers[group][command].async_send()
 
-    async def async_status(self):
-        """Request the status fo the light and the fan."""
-        light_status = await super().async_status()
-        fan_status = await self.async_fan_status()
-        if light_status == fan_status == ResponseStatus.SUCCESS:
-            return ResponseStatus.SUCCESS
-        if ResponseStatus.DIRECT_NAK_PRE_NAK in (light_status, fan_status):
-            return ResponseStatus.DIRECT_NAK_PRE_NAK
-        return ResponseStatus.FAILURE
-
-    async def async_light_status(self):
-        """Request the status of the light."""
-        return await super().async_status()
-
-    def fan_status(self):
-        """Request the status of the fan."""
-        self._handlers[STATUS_COMMAND_FAN].send()
-
-    async def async_fan_status(self):
-        """Request the status of the fan.
-
-        Returns a ResponseStatus value
-            FAILURE: Device did not acknowledge the message
-            SUCCESS: Device acknowledged the message
-            UNCLEAR: Device received the message but did not confirm the action
-
-        """
-        return await self._handlers[STATUS_COMMAND_FAN].async_send()
-
-    def _register_handlers_and_managers(self):
-        super()._register_handlers_and_managers()
-        self._handlers[STATUS_COMMAND_FAN] = StatusRequestCommand(self._address, 3)
-
     def _subscribe_to_handelers_and_managers(self):
         super()._subscribe_to_handelers_and_managers()
-        self._handlers[STATUS_COMMAND_FAN].subscribe(self._handle_fan_status)
+        self._managers[STATUS_COMMAND].add_status_type(3, self._handle_fan_status)
 
     def _register_op_flags_and_props(self):
         super()._register_op_flags_and_props()
@@ -478,17 +441,6 @@ class DimmableLightingControl_KeypadLinc(DimmableLightingControl):
         """Trigger an All-Link group off."""
         cmd = TriggerSceneOffCommandHandler(self._address, group)
         return await cmd.async_send(fast)
-
-    async def async_status(self):
-        """Check the status of the device."""
-        retries = 5
-        status = ResponseStatus.UNSENT
-        while retries and status != ResponseStatus.SUCCESS:
-            status0 = await super().async_status()
-            status1 = await self._handlers[GET_LEDS_COMMAND].async_send()
-            status = multiple_status(status0, status1)
-            retries -= 1
-        return status
 
     def set_radio_buttons(self, buttons: Iterable):
         """Set a group of buttons to act as radio buttons.
@@ -636,25 +588,29 @@ class DimmableLightingControl_KeypadLinc(DimmableLightingControl):
     def _register_handlers_and_managers(self):
         super()._register_handlers_and_managers()
         self._handlers[SET_LEDS_COMMAND] = SetLedsCommandHandler(address=self.address)
-        self._handlers[GET_LEDS_COMMAND] = StatusRequestCommand(
-            self._address, status_type=1
-        )
 
     def _register_groups(self):
         for button in self._buttons:
-            name = self._buttons[button]
+            name = self._buttons[button][0]
+            status_type = self._buttons[button][1]
             if button == 1:
                 self._groups[button] = OnLevel(
-                    name=name, address=self._address, group=button
+                    name=name,
+                    address=self._address,
+                    group=button,
+                    status_type=status_type,
                 )
             else:
                 self._groups[button] = OnOff(
-                    name=name, address=self._address, group=button
+                    name=name,
+                    address=self._address,
+                    group=button,
+                    status_type=status_type,
                 )
 
     def _subscribe_to_handelers_and_managers(self):
         super()._subscribe_to_handelers_and_managers()
-        self._handlers[GET_LEDS_COMMAND].subscribe(self._led_status)
+        self._managers[STATUS_COMMAND].add_status_type(1, self._led_status)
         for group in self._buttons:
             if group != 1:
                 led_method = partial(self._async_led_follow_check, group=group)
@@ -790,11 +746,11 @@ class DimmableLightingControl_KeypadLinc_6(DimmableLightingControl_KeypadLinc):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the DimmableLightingControl_KeypadLinc_6 class."""
         buttons = {
-            1: DIMMABLE_LIGHT_MAIN,
-            3: ON_OFF_SWITCH_A,
-            4: ON_OFF_SWITCH_B,
-            5: ON_OFF_SWITCH_C,
-            6: ON_OFF_SWITCH_D,
+            1: (DIMMABLE_LIGHT_MAIN, 0),
+            3: (ON_OFF_SWITCH_A, 1),
+            4: (ON_OFF_SWITCH_B, 1),
+            5: (ON_OFF_SWITCH_C, 1),
+            6: (ON_OFF_SWITCH_D, 1),
         }
         super().__init__(
             address=address,
@@ -813,14 +769,14 @@ class DimmableLightingControl_KeypadLinc_8(DimmableLightingControl_KeypadLinc):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the DimmableLightingControl_KeypadLinc_6 class."""
         buttons = {
-            1: DIMMABLE_LIGHT_MAIN,
-            2: ON_OFF_SWITCH_B,
-            3: ON_OFF_SWITCH_C,
-            4: ON_OFF_SWITCH_D,
-            5: ON_OFF_SWITCH_E,
-            6: ON_OFF_SWITCH_F,
-            7: ON_OFF_SWITCH_G,
-            8: ON_OFF_SWITCH_H,
+            1: (DIMMABLE_LIGHT_MAIN, 0),
+            2: (ON_OFF_SWITCH_B, 1),
+            3: (ON_OFF_SWITCH_C, 1),
+            4: (ON_OFF_SWITCH_D, 1),
+            5: (ON_OFF_SWITCH_E, 1),
+            6: (ON_OFF_SWITCH_F, 1),
+            7: (ON_OFF_SWITCH_G, 1),
+            8: (ON_OFF_SWITCH_H, 1),
         }
         super().__init__(
             address=address,
@@ -836,23 +792,18 @@ class DimmableLightingControl_KeypadLinc_8(DimmableLightingControl_KeypadLinc):
 class DimmableLightingControl_Dial(I3VariableResponderBase):
     """Dimmable i3 Dial."""
 
-    def _register_handlers_and_managers(self):
-        """Register command handlers and managers."""
-        super()._register_handlers_and_managers()
-        self._handlers[STATUS_COMMAND] = StatusRequestCommand(
-            self._address, status_type=2
-        )
-
     def _subscribe_to_handelers_and_managers(self):
         """Subscribe methods to handlers and managers."""
         super()._subscribe_to_handelers_and_managers()
+        self._managers[STATUS_COMMAND].remove_status_type(0)
+        self._managers[STATUS_COMMAND].add_status_type(2, self._handle_status)
         for group, group_prop in self._groups.items():
             if isinstance(group_prop, OnLevel):
                 self._handlers[group][MANUAL_CHANGE].subscribe(
                     self._async_on_manual_change
                 )
 
-    async def _async_on_manual_change(self):
+    async def _async_on_manual_change(self, group=None):
         """Respond to a manual change of the device."""
         await self.async_status()
 
@@ -880,10 +831,10 @@ class DimmableLightingControl_I3_KeypadLinc_4(I3VariableResponderBase):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the DimmableLightingControl_I3_KeypadLink_4 class."""
         buttons = {
-            1: ON_OFF_SWITCH_A,
-            2: ON_OFF_SWITCH_B,
-            3: ON_OFF_SWITCH_C,
-            4: ON_OFF_SWITCH_D,
+            1: (ON_OFF_SWITCH_A, 1),
+            2: (ON_OFF_SWITCH_B, 1),
+            3: (ON_OFF_SWITCH_C, 1),
+            4: (ON_OFF_SWITCH_D, 1),
         }
         super().__init__(
             address=address,
@@ -977,22 +928,6 @@ class DimmableLightingControl_I3_KeypadLinc_4(I3VariableResponderBase):
         """Trigger an All-Link group off."""
         cmd = TriggerSceneOffCommandHandler(self._address, group)
         return await cmd.async_send(fast)
-
-    async def async_status(self):
-        """Check the status of the device."""
-        retries = 5
-        status = ResponseStatus.UNSENT
-        while retries and status != ResponseStatus.SUCCESS:
-            status0 = await super().async_status()
-            status1 = await self._handlers[GET_LEDS_COMMAND].async_send()
-            status = multiple_status(status0, status1)
-            retries -= 1
-        return status
-
-    async def async_group_on(self, group: int) -> ResponseStatus:
-        """Trigger a group on."""
-        cmd = GroupOnCommand(address=self._address)
-        return await cmd.async_send(group=group)
 
     async def async_group_off(self, group: int) -> ResponseStatus:
         """Trigger a group off."""
@@ -1205,9 +1140,6 @@ class DimmableLightingControl_I3_KeypadLinc_4(I3VariableResponderBase):
     def _register_handlers_and_managers(self):
         super()._register_handlers_and_managers()
         self._handlers[SET_LEDS_COMMAND] = SetLedsCommandHandler(address=self.address)
-        self._handlers[GET_LEDS_COMMAND] = StatusRequestCommand(
-            self._address, status_type=1
-        )
         self._add_ext_prop_write_manager(
             {3: self._operating_flags[TRIGGER_GROUP_MASK]}, 0x0C, 0x00, 0x00
         )
@@ -1215,7 +1147,7 @@ class DimmableLightingControl_I3_KeypadLinc_4(I3VariableResponderBase):
     def _subscribe_to_handelers_and_managers(self):
         # Not running super due to the LOAD_BUTTON_NUMBER config property
         super()._subscribe_to_handelers_and_managers()
-        self._handlers[GET_LEDS_COMMAND].subscribe(self._async_handle_led_status)
+        self._managers[STATUS_COMMAND].add_status_type(1, self._async_handle_led_status)
         for group in self._buttons:
             led_method = partial(self._async_led_follow_check, group=group)
             self._managers[group][ON_LEVEL_MANAGER].subscribe(

--- a/pyinsteon/device_types/dimmable_lighting_control.py
+++ b/pyinsteon/device_types/dimmable_lighting_control.py
@@ -858,7 +858,7 @@ class DimmableLightingControl_I3_KeypadLinc_4(I3VariableResponderBase):
         """Turn on the button LED."""
         group = self.load_button if not group else group
         led_kwargs = {}
-        event = OFF_FAST_EVENT if fast else OFF_EVENT
+        event = ON_FAST_EVENT if fast else ON_EVENT
         result_load = ResponseStatus.SUCCESS
         result_led = ResponseStatus.SUCCESS
         if group != self.load_button:

--- a/pyinsteon/device_types/general_controller.py
+++ b/pyinsteon/device_types/general_controller.py
@@ -1,4 +1,5 @@
 """General controller devices (cat: 0x00)."""
+
 from ..aldb.no_aldb import NoALDB
 from ..config import (
     GROUPED_ON,
@@ -8,7 +9,6 @@ from ..config import (
     SEND_ON_ONLY,
     STAY_AWAKE_ON,
 )
-from ..constants import ResponseStatus
 from ..groups import (
     ON_OFF_SWITCH_A,
     ON_OFF_SWITCH_B,
@@ -40,12 +40,12 @@ class GeneralController_ControlLinc(VariableControllerBase):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the GeneralController_ControlLinc class."""
         buttons = {
-            1: ON_OFF_SWITCH_A,
-            2: ON_OFF_SWITCH_B,
-            3: ON_OFF_SWITCH_C,
-            4: ON_OFF_SWITCH_D,
-            5: ON_OFF_SWITCH_E,
-            6: ON_OFF_SWITCH_F,
+            1: (ON_OFF_SWITCH_A, None),
+            2: (ON_OFF_SWITCH_B, None),
+            3: (ON_OFF_SWITCH_C, None),
+            4: (ON_OFF_SWITCH_D, None),
+            5: (ON_OFF_SWITCH_E, None),
+            6: (ON_OFF_SWITCH_F, None),
         }
         super().__init__(
             address, cat, subcat, firmware, description, model, buttons=buttons
@@ -58,12 +58,12 @@ class GeneralController_RemoteLinc(BatteryDeviceBase, VariableControllerBase):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the GeneralController_RemoteLinc class."""
         buttons = {
-            1: ON_OFF_SWITCH_A,
-            2: ON_OFF_SWITCH_B,
-            3: ON_OFF_SWITCH_C,
-            4: ON_OFF_SWITCH_D,
-            5: ON_OFF_SWITCH_E,
-            6: ON_OFF_SWITCH_F,
+            1: (ON_OFF_SWITCH_A, None),
+            2: (ON_OFF_SWITCH_B, None),
+            3: (ON_OFF_SWITCH_C, None),
+            4: (ON_OFF_SWITCH_D, None),
+            5: (ON_OFF_SWITCH_E, None),
+            6: (ON_OFF_SWITCH_F, None),
         }
         super().__init__(
             address, cat, subcat, firmware, description, model, buttons=buttons
@@ -93,10 +93,6 @@ class GeneralController_MiniRemoteBase(BatteryDeviceBase, VariableControllerBase
         )
         self._database_delta = 0
 
-    async def async_status(self, group=0):
-        """Return success always."""
-        return ResponseStatus.SUCCESS
-
     def _register_op_flags_and_props(self):
         super()._register_op_flags_and_props()
         self._add_operating_flag(PROGRAM_LOCK_ON, 0, 0, 0, 1)
@@ -112,7 +108,7 @@ class GeneralController_MiniRemote_Switch(GeneralController_MiniRemoteBase):
 
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the GeneralController_MiniRemote_Switch class."""
-        buttons = {1: ON_OFF_SWITCH_A, 2: ON_OFF_SWITCH_B}
+        buttons = {1: (ON_OFF_SWITCH_A, None), 2: (ON_OFF_SWITCH_B, None)}
         super().__init__(
             address, cat, subcat, firmware, description, model, buttons=buttons
         )
@@ -124,10 +120,10 @@ class GeneralController_MiniRemote_4(GeneralController_MiniRemoteBase):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the GeneralController_MiniRemote_4 class."""
         buttons = {
-            1: ON_OFF_SWITCH_A,
-            2: ON_OFF_SWITCH_B,
-            3: ON_OFF_SWITCH_C,
-            4: ON_OFF_SWITCH_D,
+            1: (ON_OFF_SWITCH_A, None),
+            2: (ON_OFF_SWITCH_B, None),
+            3: (ON_OFF_SWITCH_C, None),
+            4: (ON_OFF_SWITCH_D, None),
         }
         super().__init__(
             address, cat, subcat, firmware, description, model, buttons=buttons
@@ -140,14 +136,14 @@ class GeneralController_MiniRemote_8(GeneralController_MiniRemoteBase):
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the GeneralController_MiniRemote_8 class."""
         buttons = {
-            1: ON_OFF_SWITCH_B,
-            2: ON_OFF_SWITCH_A,
-            3: ON_OFF_SWITCH_D,
-            4: ON_OFF_SWITCH_C,
-            5: ON_OFF_SWITCH_F,
-            6: ON_OFF_SWITCH_E,
-            7: ON_OFF_SWITCH_H,
-            8: ON_OFF_SWITCH_G,
+            1: (ON_OFF_SWITCH_B, None),
+            2: (ON_OFF_SWITCH_A, None),
+            3: (ON_OFF_SWITCH_D, None),
+            4: (ON_OFF_SWITCH_C, None),
+            5: (ON_OFF_SWITCH_F, None),
+            6: (ON_OFF_SWITCH_E, None),
+            7: (ON_OFF_SWITCH_H, None),
+            8: (ON_OFF_SWITCH_G, None),
         }
         super().__init__(
             address, cat, subcat, firmware, description, model, buttons=buttons

--- a/pyinsteon/device_types/open_close_responder_base.py
+++ b/pyinsteon/device_types/open_close_responder_base.py
@@ -1,16 +1,10 @@
 """Dimmable Lighting Control Devices (CATEGORY 0x01)."""
+
 from ..handlers.to_device.off import OffCommand
 from ..handlers.to_device.off_fast import OffFastCommand
 from ..handlers.to_device.on_fast import OnFastCommand
 from ..handlers.to_device.on_level import OnLevelCommand
-from ..handlers.to_device.status_request import StatusRequestCommand
-from .device_commands import (
-    OFF_COMMAND,
-    OFF_FAST_COMMAND,
-    ON_COMMAND,
-    ON_FAST_COMMAND,
-    STATUS_COMMAND,
-)
+from .device_commands import OFF_COMMAND, OFF_FAST_COMMAND, ON_COMMAND, ON_FAST_COMMAND
 from .open_close_controller_base import OpenCloseControllerBase
 
 
@@ -77,14 +71,8 @@ class OpenCloseResponderBase(OpenCloseControllerBase):
         command = OFF_FAST_COMMAND if fast else OFF_COMMAND
         return await self._handlers[group][command].async_send()
 
-    # pylint: disable=arguments-differ
-    async def async_status(self):
-        """Get the status of the device state."""
-        return await self._handlers[STATUS_COMMAND].async_send()
-
     def _register_handlers_and_managers(self):
         super()._register_handlers_and_managers()
-        self._handlers[STATUS_COMMAND] = StatusRequestCommand(self._address)
         group = 1
         if self._handlers.get(group) is None:
             self._handlers[group] = {}

--- a/pyinsteon/device_types/security_health_safety.py
+++ b/pyinsteon/device_types/security_health_safety.py
@@ -1,4 +1,5 @@
 """Security, Heath and Safety device types."""
+
 from ..config import (
     AMBIENT_LIGHT_INTENSITY,
     BATTERY_LEVEL,
@@ -94,7 +95,7 @@ class SecurityHealthSafety_DoorSensor(BatteryDeviceBase, OnOffControllerBase):
 
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the SecurityHealthSafety_DoorSensor class."""
-        buttons = {1: DOOR_SENSOR}
+        buttons = {1: (DOOR_SENSOR, None)}
         super().__init__(
             address=address,
             cat=cat,
@@ -225,7 +226,7 @@ class SecurityHealthSafety_MotionSensor(BatteryDeviceBase, OnOffControllerBase):
 
     def __init__(self, address, cat, subcat, firmware=0x00, description="", model=""):
         """Init the SecurityHealthSafety_DoorSensor class."""
-        buttons = {1: MOTION_SENSOR}
+        buttons = {1: (MOTION_SENSOR, None)}
         self._light_manager = OnLevelManager(address, self.LIGHT_GROUP)
         self._low_battery_manager = LowBatteryManager(address, self.LOW_BATTERY_GROUP)
         super().__init__(

--- a/pyinsteon/device_types/variable_controller_base.py
+++ b/pyinsteon/device_types/variable_controller_base.py
@@ -4,8 +4,8 @@ from ..default_link import DefaultLink
 from ..events import OFF_EVENT, OFF_FAST_EVENT, ON_EVENT, ON_FAST_EVENT, Event
 from ..groups import DIMMABLE_LIGHT
 from ..groups.on_level import OnLevel
-from ..handlers.to_device.status_request import StatusRequestCommand
 from ..managers.on_level_manager import OnLevelManager
+from ..managers.status_manager import StatusManager
 from .device_base import Device
 from .device_commands import STATUS_COMMAND
 
@@ -26,20 +26,8 @@ class VariableControllerBase(Device):
         buttons=None,
     ):
         """Init the VariableControllerBase class."""
-        self._buttons = {1: DIMMABLE_LIGHT} if buttons is None else buttons
+        self._buttons = {1: (DIMMABLE_LIGHT, 0)} if buttons is None else buttons
         super().__init__(address, cat, subcat, firmware, description, model)
-
-    # pylint: disable=arguments-differ
-    async def async_status(self):
-        """Request the status of the device.
-
-        Returns a ResponseStatus value
-            FAILURE: Device did not acknowledge the message
-            SUCCESS: Device acknowledged the message
-            UNCLEAR: Device received the message but did not confirm the action
-
-        """
-        return await self._handlers[STATUS_COMMAND].async_send()
 
     def _register_default_links(self):
         """Register default links.
@@ -64,7 +52,7 @@ class VariableControllerBase(Device):
 
     def _register_handlers_and_managers(self):
         super()._register_handlers_and_managers()
-        self._handlers[STATUS_COMMAND] = StatusRequestCommand(self._address)
+        self._managers[STATUS_COMMAND] = StatusManager(self._address)
         for group in self._buttons:
             if self._managers.get(group) is None:
                 self._managers[group] = {}
@@ -75,8 +63,11 @@ class VariableControllerBase(Device):
     def _register_groups(self):
         super()._register_groups()
         for group in self._buttons:
-            name = self._buttons[group]
-            self._groups[group] = OnLevel(name=name, address=self._address, group=group)
+            name = self._buttons[group][0]
+            status_type = self._buttons[group][1]
+            self._groups[group] = OnLevel(
+                name=name, address=self._address, group=group, status_type=status_type
+            )
 
     def _register_events(self):
         super()._register_events()
@@ -99,7 +90,9 @@ class VariableControllerBase(Device):
 
     def _subscribe_to_handelers_and_managers(self):
         super()._subscribe_to_handelers_and_managers()
-        self._handlers[STATUS_COMMAND].subscribe(self._handle_status)
+        self._managers[STATUS_COMMAND].add_status_type(
+            status_type=0, callback_function=self._handle_status
+        )
         for group in self._buttons:
             state = self._groups[group]
             self._managers[group][ON_LEVEL_MANAGER].subscribe(state.set_value)

--- a/pyinsteon/device_types/variable_responder_base.py
+++ b/pyinsteon/device_types/variable_responder_base.py
@@ -1,9 +1,9 @@
 """Dimmable Lighting Control Devices (CATEGORY 0x01)."""
+
 from ..handlers.to_device.off import OffCommand
 from ..handlers.to_device.off_fast import OffFastCommand
 from ..handlers.to_device.on_fast import OnFastCommand
 from ..handlers.to_device.on_level import OnLevelCommand
-from ..handlers.to_device.status_request import StatusRequestCommand
 from .device_commands import (
     OFF_COMMAND,
     OFF_FAST_COMMAND,
@@ -77,13 +77,13 @@ class VariableResponderBase(VariableControllerBase):
         command = OFF_FAST_COMMAND if fast else OFF_COMMAND
         return await self._handlers[group][command].async_send()
 
-    async def async_status(self):
-        """Get the status of the device state."""
-        return await self._handlers[STATUS_COMMAND].async_send()
+    async def async_status(self, group=None):
+        """Get the device status."""
+        status_type = self._groups[group].status_type if group is not None else None
+        return await self._managers[STATUS_COMMAND].async_status(status_type)
 
     def _register_handlers_and_managers(self):
         super()._register_handlers_and_managers()
-        self._handlers[STATUS_COMMAND] = StatusRequestCommand(self._address)
         for group in self._buttons:
             if self._handlers.get(group) is None:
                 self._handlers[group] = {}

--- a/pyinsteon/groups/fan.py
+++ b/pyinsteon/groups/fan.py
@@ -1,4 +1,5 @@
 """Fan On Level state."""
+
 from ..address import Address
 from ..constants import FanSpeed, FanSpeedRange
 from .group_base import GroupBase
@@ -8,10 +9,17 @@ class FanOnLevel(GroupBase):
     """On / Off state."""
 
     def __init__(
-        self, name: str, address: Address, group: int = 0, default: FanSpeed = None
+        self,
+        name: str,
+        address: Address,
+        group: int = 0,
+        default: FanSpeed = None,
+        status_type: int = 0,
     ):
         """Init the FanOnLevel class."""
-        super().__init__(name, address, group, default, value_type=FanSpeed)
+        super().__init__(
+            name, address, group, default, value_type=FanSpeed, status_type=status_type
+        )
         self._is_dimmable = True
 
     # pylint: disable=arguments-differ

--- a/pyinsteon/groups/group_base.py
+++ b/pyinsteon/groups/group_base.py
@@ -12,7 +12,13 @@ class GroupBase(SubscriberBase):
     __meta__ = ABC
 
     def __init__(
-        self, name: str, address: Address, group=0, default=None, value_type: type = int
+        self,
+        name: str,
+        address: Address,
+        group=0,
+        default=None,
+        value_type: type = int,
+        status_type: int = 0,
     ):
         """Init the StateBase class."""
         self._address = address
@@ -23,6 +29,7 @@ class GroupBase(SubscriberBase):
         self._value = int(default) if default is not None else None
         self._type = value_type
         self._is_dimmable: bool = False
+        self._status_type = status_type
 
     @property
     def is_dimmable(self) -> bool:
@@ -71,6 +78,11 @@ class GroupBase(SubscriberBase):
             value=self._value,
             group=self._group,
         )
+
+    @property
+    def status_type(self):
+        """Return the status type to get the group state."""
+        return self._status_type
 
     @abstractmethod
     def set_value(self, **kwargs):

--- a/pyinsteon/groups/on_level.py
+++ b/pyinsteon/groups/on_level.py
@@ -1,4 +1,5 @@
 """On Leve state."""
+
 import logging
 
 from ..address import Address
@@ -11,10 +12,17 @@ class OnLevel(GroupBase):
     """Variable On Level state."""
 
     def __init__(
-        self, name: str, address: Address, group: int = 0, default: int = None
+        self,
+        name: str,
+        address: Address,
+        group: int = 0,
+        default: int = None,
+        status_type: int = 0,
     ):
         """Init the OnLevel class."""
-        super().__init__(name, address, group, default, value_type=int)
+        super().__init__(
+            name, address, group, default, value_type=int, status_type=status_type
+        )
         self._is_dimmable: bool = True
 
     @property

--- a/pyinsteon/groups/on_off.py
+++ b/pyinsteon/groups/on_off.py
@@ -1,4 +1,5 @@
 """On / Off state."""
+
 from ..address import Address
 from .group_base import GroupBase
 
@@ -7,10 +8,17 @@ class OnOff(GroupBase):
     """On / Off state."""
 
     def __init__(
-        self, name: str, address: Address, group: int = 0, default: int = None
+        self,
+        name: str,
+        address: Address,
+        group: int = 0,
+        default: int = None,
+        status_type: int = 0,
     ):
         """Init the OnLevel class."""
-        super().__init__(name, address, group, default, value_type=int)
+        super().__init__(
+            name, address, group, default, value_type=int, status_type=status_type
+        )
 
     # pylint: disable=arguments-differ
     def set_value(self, on_level):

--- a/pyinsteon/groups/open_close.py
+++ b/pyinsteon/groups/open_close.py
@@ -1,4 +1,5 @@
 """Open / Close sensor groups."""
+
 from ..address import Address
 from .group_base import GroupBase
 
@@ -7,10 +8,17 @@ class NormallyOpen(GroupBase):
     """Normally open sensor state."""
 
     def __init__(
-        self, name: str, address: Address, group: int = 0, default: int = None
+        self,
+        name: str,
+        address: Address,
+        group: int = 0,
+        default: int = None,
+        status_type: int = 0,
     ):
         """Init the OnLevel class."""
-        super().__init__(name, address, group, default, value_type=int)
+        super().__init__(
+            name, address, group, default, value_type=int, status_type=status_type
+        )
 
     # pylint: disable=arguments-differ
     def set_value(self, on_level):
@@ -23,10 +31,17 @@ class NormallyClosed(GroupBase):
     """Normally closed sensor state."""
 
     def __init__(
-        self, name: str, address: Address, group: int = 0, default: int = None
+        self,
+        name: str,
+        address: Address,
+        group: int = 0,
+        default: int = None,
+        status_type: int = 0,
     ):
-        """Init the OnLevel class."""
-        super().__init__(name, address, group, default, value_type=int)
+        """Init the NormallyClosed class."""
+        super().__init__(
+            name, address, group, default, value_type=int, status_type=status_type
+        )
 
     # pylint: disable=arguments-differ
     def set_value(self, on_level):

--- a/pyinsteon/groups/thermostat.py
+++ b/pyinsteon/groups/thermostat.py
@@ -1,4 +1,5 @@
 """Temperature state."""
+
 from ..address import Address
 from ..constants import ThermostatMode
 from .group_base import GroupBase
@@ -13,9 +14,12 @@ class Temperature(GroupBase):
         address: Address,
         group: int = 0,
         default: float = None,
+        status_type: int = 0,
     ):
         """Init the Temperature class."""
-        super().__init__(name, address, group, default, value_type=float)
+        super().__init__(
+            name, address, group, default, value_type=float, status_type=status_type
+        )
         self._is_dimmable = True
 
     # pylint: disable=arguments-differ

--- a/pyinsteon/groups/wet_dry.py
+++ b/pyinsteon/groups/wet_dry.py
@@ -1,4 +1,5 @@
 """Wet / Dry state."""
+
 from ..address import Address
 from .group_base import GroupBase
 
@@ -7,10 +8,17 @@ class Dry(GroupBase):
     """Dry state."""
 
     def __init__(
-        self, name: str, address: Address, group: int = 0, default: bool = None
+        self,
+        name: str,
+        address: Address,
+        group: int = 0,
+        default: bool = None,
+        status_type: int = 0,
     ):
         """Init the WetDry class."""
-        super().__init__(name, address, group, default, value_type=bool)
+        super().__init__(
+            name, address, group, default, value_type=bool, status_type=status_type
+        )
 
     # pylint: disable=arguments-differ
     def set_value(self, dry):

--- a/pyinsteon/handlers/from_device/broadcast_command.py
+++ b/pyinsteon/handlers/from_device/broadcast_command.py
@@ -1,8 +1,9 @@
 """Base class to handle Broadcast messages from devices."""
+
 from datetime import datetime
 
-from ...constants import MessageFlagType
 from .. import broadcast_handler
+from ...constants import MessageFlagType
 from ..inbound_base import InboundHandlerBase
 
 MIN_DUP = 0.7
@@ -23,18 +24,20 @@ class BroadcastCommandHandlerBase(InboundHandlerBase):
         )
         self._last_command = datetime(1, 1, 1)
         self._last_hops_left = None
+        self._last_cmd2 = None
+        self._last_userdata = None
 
     @broadcast_handler
     def receive_message(self, cmd1, cmd2, target, user_data, hops_left):
         """Receive the inbound message."""
-        if not self._is_first_message(target, hops_left):
+        if not self._is_first_message(cmd2, user_data, target, hops_left):
             return
         self._handle_message_received(cmd1, cmd2, target, user_data, hops_left)
 
     def _handle_message_received(self, cmd1, cmd2, target, user_data, hops_left):
         """Handle the received message."""
 
-    def _is_first_message(self, target, hops_left):
+    def _is_first_message(self, cmd2, user_data, target, hops_left):
         """Test if the message is a duplicate."""
         curr_time = datetime.now()
         tdelta = curr_time - self._last_command
@@ -43,8 +46,18 @@ class BroadcastCommandHandlerBase(InboundHandlerBase):
         else:
             delta = tdelta.seconds + tdelta.microseconds / 1000000
         self._last_command = curr_time
+
+        if cmd2 != self._last_cmd2 or user_data != self._last_userdata:
+            self._last_cmd2 = cmd2
+            self._last_userdata = user_data
+            self._last_hops_left = hops_left
+            return True
+        self._last_cmd2 = cmd2
+        self._last_userdata = user_data
+
         if target.middle != 0 and hops_left == self._last_hops_left and delta < MIN_DUP:
             return False
+
         if (
             self._last_hops_left is None
             or (hops_left == self._last_hops_left and delta > MIN_DUP)

--- a/pyinsteon/handlers/from_device/off_at_ramp_rate.py
+++ b/pyinsteon/handlers/from_device/off_at_ramp_rate.py
@@ -1,0 +1,24 @@
+"""Manage inbound ON command from device."""
+
+from ...address import Address
+from ...constants import RampRate
+from ...data_types.user_data import UserData
+from ...topics import OFF_AT_RAMP_RATE_INBOUND
+from .broadcast_command import BroadcastCommandHandlerBase
+
+
+class OffAtRampRateInbound(BroadcastCommandHandlerBase):
+    """Off At Ramp Rate command inbound."""
+
+    def __init__(self, address: Address, group: int):
+        """Init the OnAtRampRateInbound class."""
+        super().__init__(topic=OFF_AT_RAMP_RATE_INBOUND, address=address, group=group)
+
+    def _handle_message_received(
+        self, cmd1: int, cmd2: int, target: Address, user_data: UserData, hops_left: int
+    ):
+        """Handle the OFF command from a device."""
+        on_level = ((cmd2 >> 4) * 16) + 15
+        ramp_rate_byte = ((cmd2 & 0x0F) * 2) + 1
+        ramp_rate = RampRate(ramp_rate_byte)
+        self._call_subscribers(on_level=on_level, ramp_rate=ramp_rate)

--- a/pyinsteon/handlers/from_device/on_at_ramp_rate.py
+++ b/pyinsteon/handlers/from_device/on_at_ramp_rate.py
@@ -1,0 +1,24 @@
+"""Manage inbound ON command from device."""
+
+from ...address import Address
+from ...constants import RampRate
+from ...data_types.user_data import UserData
+from ...topics import ON_AT_RAMP_RATE_INBOUND
+from .broadcast_command import BroadcastCommandHandlerBase
+
+
+class OnAtRampRateInbound(BroadcastCommandHandlerBase):
+    """On At Ramp Rate command inbound."""
+
+    def __init__(self, address: Address, group: int):
+        """Init the OnAtRampRateInbound class."""
+        super().__init__(topic=ON_AT_RAMP_RATE_INBOUND, address=address, group=group)
+
+    def _handle_message_received(
+        self, cmd1: int, cmd2: int, target: Address, user_data: UserData, hops_left: int
+    ):
+        """Handle the OFF command from a device."""
+        on_level = ((cmd2 >> 4) * 16) + 15
+        ramp_rate_byte = ((cmd2 & 0x0F) * 2) + 1
+        ramp_rate = RampRate(ramp_rate_byte)
+        self._call_subscribers(on_level=on_level, ramp_rate=ramp_rate)

--- a/pyinsteon/handlers/to_device/status_request.py
+++ b/pyinsteon/handlers/to_device/status_request.py
@@ -1,4 +1,5 @@
 """Manage outbound ON command to a device."""
+
 import asyncio
 
 from .. import ack_handler, status_handler
@@ -13,9 +14,14 @@ class StatusRequestCommand(DirectCommandHandlerBase):
 
     def __init__(self, address, status_type: int = 0):
         """Init the OnLevelCommand class."""
-        super().__init__(topic=STATUS_REQUEST, address=address, group=None)
         self._status_type = status_type
+        super().__init__(topic=STATUS_REQUEST, address=address, group=None)
         self._subscriber_topic = f"handler.{self._address.id}.{self._status_type}.{STATUS_REQUEST}.{str(MessageFlagType.DIRECT).lower()}"
+
+    @property
+    def status_type(self):
+        """Return the status type."""
+        return self._status_type
 
     # pylint: disable=arguments-differ, useless-super-delegation
     async def async_send(self):

--- a/pyinsteon/managers/status_manager.py
+++ b/pyinsteon/managers/status_manager.py
@@ -1,0 +1,102 @@
+"""Manage status requests.
+
+Status requests should not run more often than necessary due to the nature of linking the status message response to the original request.
+If status messages overlap, the response can be very difficult to associate to the original request. This is especially important for
+devices that have multiple status messages.
+
+Logic:
+first call always happens when requested
+second call happens
+    if
+        No other call is in progress then run
+    else
+        if
+            Another call is in queue then cancel
+        else
+            Wait until the first call is done then run
+
+"""
+
+from asyncio import Lock
+from logging import DEBUG, getLogger
+from typing import Callable, Dict, Union
+
+from ..address import Address
+from ..constants import ResponseStatus
+from ..handlers.to_device.status_request import StatusRequestCommand
+from ..utils import multiple_status
+
+_LOGGER = getLogger(__name__)
+_LOGGER.setLevel(DEBUG)
+
+
+class StatusManager:
+    """Status manager."""
+
+    def __init__(self, address: Address):
+        """Init the StatusManager class."""
+        self._address = Address(address)
+        self._status_cmds: Dict[int, StatusRequestCommand] = {}
+        self._callbacks: Dict[int, Callable] = {}
+        self._call_waiting: bool = False
+        self._run_lock = Lock()
+
+    def add_status_type(self, status_type: int, callback_function: Callable):
+        """Add a status request type."""
+        self.remove_status_type(status_type=status_type)
+
+        status_cmd = StatusRequestCommand(self._address, status_type)
+        status_cmd.subscribe(callback_function)
+        self._status_cmds[status_type] = status_cmd
+        self._callbacks[status_type] = callback_function
+
+    def remove_status_type(self, status_type: int):
+        """Remove a status request type and unsubscribe to command responses."""
+        status_cmd: StatusRequestCommand = self._status_cmds.get(status_type)
+        if status_cmd:
+            status_cmd.unsubscribe(self._callbacks[status_type])
+            self._callbacks.pop(status_type)
+            self._status_cmds.pop(status_type)
+
+    async def async_status(
+        self, status_type: Union[int, None] = None
+    ) -> ResponseStatus:
+        """Send the status request."""
+        if self._call_waiting:
+            # No need for this call because an existing call is already scheduled
+            _LOGGER.debug("No need to run this status request.")
+            return ResponseStatus.SUCCESS
+
+        if self._run_lock.locked():
+            # This is the second call and needs to wait for the first call to finish
+            # Make sure any subsequent calls know there is already a call waiting
+            _LOGGER.debug(
+                "This status request is waiting for the prior request to finish."
+            )
+            self._call_waiting = True
+
+        results = []
+        if status_type is not None and status_type not in self._status_cmds:
+            status_type = None
+        status_types = (
+            [status_type] if status_type is not None else self._status_cmds.keys()
+        )
+        async with self._run_lock:
+            for curr_status_type in status_types:
+                result = await self._async_status(self._status_cmds[curr_status_type])
+                results.append(result)
+            self._call_waiting = False
+
+        return multiple_status(*results)
+
+    async def _async_status(self, status_cmd: Callable) -> ResponseStatus:
+        """Execute the status command."""
+        retries = 2
+        result = ResponseStatus.UNSENT
+        while retries and result not in [
+            ResponseStatus.SUCCESS,
+            ResponseStatus.DIRECT_NAK_ALDB,
+        ]:
+            result = await status_cmd.async_send()
+            retries -= 1
+        return result

--- a/pyinsteon/managers/thermostat_status_manager.py
+++ b/pyinsteon/managers/thermostat_status_manager.py
@@ -1,4 +1,5 @@
 """Thermostat status manager."""
+
 import asyncio
 from collections import namedtuple
 import logging
@@ -70,7 +71,7 @@ class GetThermostatStatus:
         self._status_listeners = []
         self._set_point_listeners = []
 
-    async def async_status(self):
+    async def async_status(self, group=None):
         """Read the device status."""
         status1 = await self._status()
         status2 = await self._set_point()

--- a/pyinsteon/protocol/protocol.py
+++ b/pyinsteon/protocol/protocol.py
@@ -229,9 +229,14 @@ class Protocol(asyncio.Protocol):
                     if msg is None:
                         return
                     _LOGGER_MSG.debug("TX: %s", repr(msg))
-                    if _LOGGER_MSG.level == 0 or _LOGGER_MSG.level > logging.DEBUG:
+                    if (
+                        _LOGGER_MSG.level == 0 or _LOGGER_MSG.level > logging.DEBUG
+                    ) and (
+                        _LOGGER_PYINSTEON.level == 0
+                        or _LOGGER_PYINSTEON.level > logging.DEBUG
+                    ):
                         for addr in _get_addresses_in_msg(msg):
-                            logger = logging.getLogger(f"pyinsteon.{addr.id}")
+                            logger = logging.getLogger(f"pyinsteon.{Address(addr).id}")
                             logger.debug("TX: %s", repr(msg))
                     while not self._last_message.empty():
                         self._last_message.get()

--- a/pyinsteon/protocol/protocol.py
+++ b/pyinsteon/protocol/protocol.py
@@ -6,6 +6,7 @@ import logging
 from queue import SimpleQueue
 from typing import Union
 
+from ..address import Address
 from ..constants import AckNak
 from ..utils import log_error, publish_topic
 from .command_to_msg import register_command_handlers
@@ -14,6 +15,7 @@ from .messages.outbound import outbound_write_manager, register_outbound_handler
 from .msg_to_topic import convert_to_topic
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER_PYINSTEON = logging.getLogger("pyinsteon")
 _LOGGER_MSG = logging.getLogger("pyinsteon.messages")
 MAX_RECONNECT_WAIT_TIME = 300
 
@@ -37,9 +39,11 @@ def _get_addresses_in_msg(msg):
 async def _publish_message(msg):
     """Convert an inbound message to a topic and publish to listeners."""
     _LOGGER_MSG.debug("RX: %s", repr(msg))
-    if _LOGGER_MSG.level == 0 or _LOGGER_MSG.level > logging.DEBUG:
+    if (_LOGGER_MSG.level == 0 or _LOGGER_MSG.level > logging.DEBUG) and (
+        _LOGGER_PYINSTEON.level == 0 or _LOGGER_PYINSTEON.level > logging.DEBUG
+    ):
         for addr in _get_addresses_in_msg(msg):
-            logger = logging.getLogger(f"pyinsteon.{addr.id}")
+            logger = logging.getLogger(f"pyinsteon.{Address(addr).id}")
             logger.debug("RX: %s", repr(msg))
     topic = None
     kwargs = {}

--- a/pyinsteon/topics.py
+++ b/pyinsteon/topics.py
@@ -1,4 +1,5 @@
 """Constants used to ensure topic consistantancy."""
+
 DEVICE_LIST_CHANGED = "device_list_changed"
 
 STANDARD_RECEIVED = "standard_message_received"
@@ -74,9 +75,11 @@ PEEK = "peek"
 PEEK_INTERNAL = "peek_internal"
 POKE_INTERNAL = "poke_internal"
 ON_AT_RAMP_RATE = "on_at_ramp_rate"
+ON_AT_RAMP_RATE_INBOUND = "on_at_ramp_rate_inbound"
 EXTENDED_GET_SET = "extended_get_set"
 EXTENDED_GET_RESPONSE = "extended_get_response"
 OFF_AT_RAMP_RATE = "off_at_ramp_rate"
+OFF_AT_RAMP_RATE_INBOUND = "off_at_ramp_rate_inbound"
 EXTENDED_READ_WRITE_ALDB = "extended_read_write_aldb"
 EXTENDED_TRIGGER_ALL_LINK = "extended_trigger_all_link"
 ALDB_RECORD_RECEIVED = "aldb_record_received"

--- a/pyinsteon/utils.py
+++ b/pyinsteon/utils.py
@@ -1,4 +1,5 @@
 """Utility methods."""
+
 import asyncio
 from collections.abc import Iterable
 from enum import Enum, IntEnum
@@ -312,6 +313,11 @@ def publish_topic(topic, logger=None, **kwargs):
     if logger is None:
         logger = logging.getLogger(__name__)
     try:
+        pub_topic = pub.getDefaultTopicMgr().getTopic(topic, okIfNone=True)
+        if pub_topic:
+            for listener in pub_topic.listeners:
+                if listener.isDead():
+                    pub_topic.unsubscribe(listener)
         pub.sendMessage(topic, **kwargs)
     except pub.ExcHandlerError as exc:
         logger.error("pubsub ExcHandlerError")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,9 @@ disable = [
     "line-too-long",
     "deprecated-typing-alias",
     "consider-alternative-union-syntax",
+    "duplicate-code",  # to be added back after cleanup
+    "cyclic-import",
+    "use-yield-from"
 ]
 enable = [
     #"useless-suppression",  # temporarily every now and then to clean them up

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,13 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Home Automation",
 ]
-requires-python = ">=3.8.0"
+requires-python = ">=3.9.0"
 dependencies    = [
         "pyserial",
         "pyserial-asyncio>=0.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "pyinsteon"
-version     = "1.5.4"
+version     = "1.6.0"
 license     = {text = "MIT License"}
 description = "Open-source Insteon home automation module running on Python 3."
 readme      = "DESCRIPTION.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "pyinsteon"
-version     = "1.5.3"
+version     = "1.5.4"
 license     = {text = "MIT License"}
 description = "Open-source Insteon home automation module running on Python 3."
 readme      = "DESCRIPTION.rst"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,16 +2,16 @@
 # make new things fail. Manually update these pins when pulling in a
 # new version
 flake8-docstrings==1.7.0
-flake8==6.1.0
-flake8-noqa==1.3.2
+flake8==7.0.0
+flake8-noqa==1.4.0
 flake8-comprehensions==3.14.0
-pyflakes==3.1.0
-pycodestyle==2.11.0
+pyflakes==3.2.0
+pycodestyle==2.11.1
 pydocstyle==6.3.0
-pylint==2.17.5
-isort==5.12.0
+pylint==3.1.0
+isort==5.13.2
 async_generator
-black==23.7.0
-pytest-cov==4.1.0
-pytest==7.4.1
-pre-commit==3.4.0
+black==24.4.2
+pytest-cov==5.0.0
+pytest==8.2.0
+pre-commit==3.7.0

--- a/tests/test_devices/test_i3_dial.py
+++ b/tests/test_devices/test_i3_dial.py
@@ -1,0 +1,104 @@
+"""Test the dial for the ON_AT_RAMP_RATE_INBOUND message."""
+
+import asyncio
+import unittest
+
+from pyinsteon.address import Address
+from pyinsteon.device_types.dimmable_lighting_control import (
+    DimmableLightingControl_Dial,
+)
+
+from tests import set_log_levels
+from tests.utils import (
+    DataItem,
+    TopicItem,
+    async_case,
+    async_protocol_manager,
+    cmd_kwargs,
+    create_std_ext_msg,
+    random_address,
+    send_data,
+    send_topics,
+)
+
+
+class TestI3Dial(unittest.TestCase):
+    """Test creation of all devices."""
+
+    def setUp(self) -> None:
+        """Set up the test."""
+        set_log_levels(logger_topics=True)
+        return super().setUp()
+
+    @async_case
+    async def test_on_off_at_ramp_rate(self):
+        """Test the i3 Dial for On/Off at ramp rate."""
+        address = random_address()
+        target = random_address()
+        device = DimmableLightingControl_Dial(address, 0x01, 0x57, 0x00, "Dial", "PD01")
+
+        on_levels = {
+            0x0D: 15,
+            0x1D: 31,
+            0x2D: 47,
+            0x3D: 63,
+            0x4D: 79,
+            0x5D: 95,
+            0x6D: 111,
+            0x7D: 127,
+            0x8D: 143,
+            0x9D: 159,
+            0xAD: 175,
+            0xBD: 191,
+            0xCD: 207,
+            0xDD: 223,
+            0xED: 239,
+            0xFD: 255,
+        }
+        for cmd2, on_level in on_levels.items():
+            kwargs = cmd_kwargs(0x34, cmd2, None, target=target)
+            send_topics(
+                [
+                    TopicItem(
+                        topic=f"{address.id}.1.on_at_ramp_rate_inbound.all_link_broadcast",
+                        kwargs=kwargs,
+                        delay=0.01,
+                    )
+                ]
+            )
+            await asyncio.sleep(0.7)
+            assert device.groups[1].value == on_level
+
+    @async_case
+    async def test_on_off_at_ramp_rate_fast(self):
+        """Test the i3 Dial for On/Off at ramp rate."""
+        address = random_address()
+        target = Address("000001")
+        device = DimmableLightingControl_Dial(address, 0x01, 0x57, 0x00, "Dial", "PD01")
+
+        on_levels = {
+            0x0D: 15,
+            0x1D: 31,
+            0x2D: 47,
+            0x3D: 63,
+            0x4D: 79,
+            0x5D: 95,
+            0x6D: 111,
+            0x7D: 127,
+            0x8D: 143,
+            0x9D: 159,
+            0xAD: 175,
+            0xBD: 191,
+            0xCD: 207,
+            0xDD: 223,
+            0xED: 239,
+            0xFD: 255,
+        }
+        data = []
+        async with async_protocol_manager() as protocol:
+            for cmd2 in on_levels:
+                msg = create_std_ext_msg(address, 0xC7, 0x34, cmd2, None, target, None)
+                data.append(DataItem(msg, 0.1))
+            send_data(data, protocol.read_queue)
+            await asyncio.sleep(0.8 * len(on_levels) + 1)
+            assert device.groups[1].value == 255

--- a/tests/test_handlers/from_device.json
+++ b/tests/test_handlers/from_device.json
@@ -241,6 +241,42 @@
         },
         "assert_tests": {}
     },
+    "on_at_ramp_rate_inbound": {
+        "command": ".on_at_ramp_rate.OnAtRampRateInbound",
+        "params": {
+            "address": "",
+            "group": 1
+        },
+        "message": {
+            "flags": "0xC0",
+            "cmd1": "0x34",
+            "cmd2": "0x58",
+            "target": "000001",
+            "user_data": {}
+        },
+        "assert_tests": {
+            "on_level": 95,
+            "ramp_rate": 17
+        }
+    },
+    "off_at_ramp_rate_inbound": {
+        "command": ".off_at_ramp_rate.OffAtRampRateInbound",
+        "params": {
+            "address": "",
+            "group": 1
+        },
+        "message": {
+            "flags": "0xC0",
+            "cmd1": "0x35",
+            "cmd2": "0x58",
+            "target": "000001",
+            "user_data": {}
+        },
+        "assert_tests": {
+            "on_level": 95,
+            "ramp_rate": 17
+        }
+    },
     "on_fast_with_on_level": {
         "command": ".on_fast.OnFastInbound",
         "params": {

--- a/tests/test_handlers/modem_commands.json
+++ b/tests/test_handlers/modem_commands.json
@@ -86,7 +86,7 @@
                 "action": "0x20",
                 "controller": true,
                 "group": 5,
-                "target": "0ab0c",
+                "target": "0ab0c0",
                 "data1": 1,
                 "data2": 2,
                 "data3": 3
@@ -113,7 +113,7 @@
                 "action": "0x20",
                 "controller": true,
                 "group": 5,
-                "target": "0ab0c",
+                "target": "0ab0c0",
                 "data1": 1,
                 "data2": 2,
                 "data3": 3

--- a/tests/test_handlers/nak_responses.json
+++ b/tests/test_handlers/nak_responses.json
@@ -12,7 +12,8 @@
             }
         },
         "nak_count": 10,
-        "response": {}
+        "response": {},
+        "use_address": true
     },
     "cancel_all_linking": {
         "command": {
@@ -70,7 +71,7 @@
         "nak_count": 1,
         "response": {}
     },
-    "send_all_link": {
+    "send_all_link_command": {
         "command": {
             "class": ".send_all_link.SendAllLinkCommandHandler",
             "params": {},

--- a/tests/test_handlers/test_broadcast_dedup.py
+++ b/tests/test_handlers/test_broadcast_dedup.py
@@ -1,12 +1,12 @@
 """Test broadcast messages for deduplication."""
+
+from asyncio import sleep
 from random import randint
 import unittest
 from unittest.mock import patch
-from asyncio import sleep
 
 import pyinsteon
 from pyinsteon import pub
-from pyinsteon.handlers.from_device.broadcast_command import MAX_DUP, MIN_DUP
 from pyinsteon.handlers.from_device.assign_to_all_link_group import (
     AssignToAllLinkGroupCommand,
 )
@@ -14,20 +14,21 @@ from pyinsteon.handlers.from_device.delete_from_all_link_group import (
     DeleteFromAllLinkGroupCommand,
 )
 from pyinsteon.handlers.from_device.manual_change import ManualChangeInbound
-from pyinsteon.handlers.from_device.off_fast import OffFastInbound
 from pyinsteon.handlers.from_device.off import OffInbound
+from pyinsteon.handlers.from_device.off_fast import OffFastInbound
 from pyinsteon.handlers.from_device.on_fast import OnFastInbound
 from pyinsteon.handlers.from_device.on_level import OnLevelInbound
 from pyinsteon.topics import (
     ASSIGN_TO_ALL_LINK_GROUP,
     DELETE_FROM_ALL_LINK_GROUP,
-    STOP_MANUAL_CHANGE,
-    OFF_FAST,
     OFF,
-    ON_FAST,
+    OFF_FAST,
     ON,
+    ON_FAST,
+    STOP_MANUAL_CHANGE,
 )
-from pyinsteon.utils import subscribe_topic
+from pyinsteon.utils import subscribe_topic, unsubscribe_topic
+
 from tests import set_log_levels
 from tests.utils import TopicItem, async_case, cmd_kwargs, random_address, send_topics
 
@@ -83,12 +84,15 @@ class TestBroadcastMessageDedup(unittest.TestCase):
             logger_messages="info",
             logger_topics=False,
         )
-        subscribe_topic(self.handle_topics, pub.ALL_TOPICS)
+        subscribe_topic(self.handle_topics, "handler")
+
+    def tearDown(self) -> None:
+        """Tear down the test."""
+        unsubscribe_topic(self.handle_topics, "handler")
 
     async def handle_topics(self, topic=pub.AUTO_TOPIC):
         """Handle the on topic."""
-        if topic.name.startswith("handler"):
-            self.call_count += 1
+        self.call_count += 1
 
     @async_case
     async def test_dup(self):
@@ -102,17 +106,18 @@ class TestBroadcastMessageDedup(unittest.TestCase):
             for topic, command in COMMANDS.items():
                 group = randint(1, 9)
                 address = random_address()
+                # pylint: disable=unused-variable
                 if command in NO_GROUP_CMDS:
                     handler = command(address)
                 else:
-                    handler = command(address, group)
+                    handler = command(address, group)  # noqa: F841
                 topics = [
                     create_topic(topic, address, group, 3, 0),
                     create_topic(topic, address, group, 2, 0.4),
                 ]
                 self.call_count = 0
                 send_topics(topics)
-                await sleep(.5)
+                await sleep(0.5)
                 assert self.call_count == 1
 
     @async_case
@@ -130,7 +135,7 @@ class TestBroadcastMessageDedup(unittest.TestCase):
                 if command in NO_GROUP_CMDS:
                     handler = command(address)
                 else:
-                    handler = command(address, group)
+                    handler = command(address, group)  # noqa: F841
                 self.call_count = 0
                 topics = [
                     create_topic(topic, address, group, 3, 0.0),
@@ -152,10 +157,11 @@ class TestBroadcastMessageDedup(unittest.TestCase):
             for topic, command in COMMANDS.items():
                 group = randint(1, 9)
                 address = random_address()
+                # pylint: disable=unused-variable
                 if command in NO_GROUP_CMDS:
                     handler = command(address)
                 else:
-                    handler = command(address, group)
+                    handler = command(address, group)  # noqa: F841
                 self.call_count = 0
                 topics = [
                     create_topic(topic, address, group, 3, 0.0),
@@ -177,10 +183,11 @@ class TestBroadcastMessageDedup(unittest.TestCase):
             for topic, command in COMMANDS.items():
                 group = randint(1, 9)
                 address = random_address()
+                # pylint: disable=unused-variable
                 if command in NO_GROUP_CMDS:
                     handler = command(address)
                 else:
-                    handler = command(address, group)
+                    handler = command(address, group)  # noqa: F841
                 self.call_count = 0
                 topics = [
                     create_topic(topic, address, group, 2, 0.0),
@@ -202,10 +209,11 @@ class TestBroadcastMessageDedup(unittest.TestCase):
             for topic, command in COMMANDS.items():
                 group = randint(1, 9)
                 address = random_address()
+                # pylint: disable=unused-variable
                 if command in NO_GROUP_CMDS:
                     handler = command(address)
                 else:
-                    handler = command(address, group)
+                    handler = command(address, group)  # noqa: F841
                 self.call_count = 0
                 topics = [
                     create_topic(topic, address, group, 2, 0.0),
@@ -227,10 +235,11 @@ class TestBroadcastMessageDedup(unittest.TestCase):
             for topic, command in COMMANDS.items():
                 group = randint(1, 9)
                 address = random_address()
+                # pylint: disable=unused-variable
                 if command in NO_GROUP_CMDS:
                     handler = command(address)
                 else:
-                    handler = command(address, group)
+                    handler = command(address, group)  # noqa: F841
                 self.call_count = 0
                 topics = [
                     create_topic(topic, address, group, 2, 0.0),

--- a/tests/test_handlers/test_commands.py
+++ b/tests/test_handlers/test_commands.py
@@ -133,7 +133,7 @@ class TestDirectCommands(unittest.TestCase):
 
             tests = await import_commands()
             try:
-                subscribe_topic(self.validate_values, pub.ALL_TOPICS)
+                subscribe_topic(self.validate_values, "handler")
                 subscribe_topic(listen_for_ack, "ack")
 
                 for test_info in tests:
@@ -182,7 +182,7 @@ class TestDirectCommands(unittest.TestCase):
                     _LOGGER.info("Completed test: %s", test_info)
                     _LOGGER.info("")
             finally:
-                unsubscribe_topic(self.validate_values, pub.ALL_TOPICS)
+                unsubscribe_topic(self.validate_values, "handler")
                 unsubscribe_topic(listen_for_ack, "ack")
 
 

--- a/tests/test_handlers/test_inbound.py
+++ b/tests/test_handlers/test_inbound.py
@@ -1,18 +1,19 @@
 """Test the sending and receiving of direct commands using the MockPLM."""
-import json
-import unittest
+
 from asyncio import sleep
 from binascii import unhexlify
+import json
+import unittest
 
 import aiofiles
 
-import pyinsteon.handlers.from_device as commands
 from pyinsteon import pub
 from pyinsteon.address import Address
 
 # pylint: disable=unused-import
 # flake8: noqa: F401
 from pyinsteon.handlers.cancel_all_linking import CancelAllLinkingCommandHandler
+import pyinsteon.handlers.from_device as commands
 from pyinsteon.handlers.get_first_all_link_record import GetFirstAllLinkRecordHandler
 from pyinsteon.handlers.get_im_configuration import GetImConfigurationHandler
 from pyinsteon.handlers.get_im_info import GetImInfoHandler
@@ -131,9 +132,8 @@ class TestInbound(unittest.TestCase):
         """Test direct command."""
 
         async with async_protocol_manager(auto_ack=False) as protocol:
-
             tests = await import_commands()
-            subscribe_topic(self.async_validate_values, pub.ALL_TOPICS)
+            subscribe_topic(self.async_validate_values, "handler")
 
             for test_info in tests:
                 self._current_test = test_info

--- a/tests/test_handlers/test_modem_inbound.py
+++ b/tests/test_handlers/test_modem_inbound.py
@@ -1,4 +1,5 @@
 """Test the sending and receiving of direct commands using the MockPLM."""
+
 from asyncio import sleep
 from binascii import unhexlify
 import json
@@ -113,9 +114,7 @@ class TestModemInbound(unittest.TestCase):
     async def test_modem_inbound(self):
         """Test direct command."""
         async with async_protocol_manager(auto_ack=False) as protocol:
-
             tests = await import_modem_commands()
-            pub.subscribe(self.validate_values, pub.ALL_TOPICS)
 
             for test_info in tests:
                 self._current_test = test_info
@@ -129,10 +128,12 @@ class TestModemInbound(unittest.TestCase):
                 cmd = obj()
                 inbound_data = unhexlify(f"02{inbound_message}")
                 ack_response_item = DataItem(inbound_data, 0)
+                pub.subscribe(self.validate_values, f"handler.{test_info}")
                 send_data([ack_response_item], protocol.read_queue)
                 await sleep(0.2)
                 assert self._test_result
                 _LOGGER.info("Completed Test: %s", test_info)
+                pub.unsubscribe(self.validate_values, f"handler.{test_info}")
                 _LOGGER.info("")
 
 

--- a/tests/test_managers/test_link_manager.py
+++ b/tests/test_managers/test_link_manager.py
@@ -1,0 +1,599 @@
+"""Test the link manager."""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, Mock
+import warnings
+
+from pyinsteon import devices
+from pyinsteon.constants import AllLinkMode, EngineVersion, ResponseStatus
+from pyinsteon.device_types.hub import Hub
+from pyinsteon.managers import link_manager
+
+from tests import load_devices, set_log_levels
+from tests.utils import TopicItem, async_case, cmd_kwargs, random_address, send_topics
+
+test_lock = asyncio.Lock()
+
+
+def _reset_devices(addresses):
+    """Reset the device ALDB pending records."""
+    for addr in addresses:
+        device = devices[addr]
+        device.async_status = AsyncMock()
+        device.aldb.clear_pending()
+        device.aldb.async_write = AsyncMock()
+        device.aldb.async_write.call_count = 0
+        device.aldb.clear = Mock()
+        device.async_status.return_value = ResponseStatus.SUCCESS
+
+
+def _add_rec_to_aldb(device, record):
+    """Add a record to a device ALDB."""
+    hwm = None
+    for rec in device.aldb.find(target="000000"):
+        hwm = rec
+        break
+
+    if record.mem_addr == 0:
+        record.mem_addr = hwm.mem_addr
+        hwm.mem_addr = hwm.mem_addr - 8
+        records = {record.mem_addr: record, hwm.mem_addr: hwm}
+    else:
+        records = {record.mem_addr: record}
+    device.aldb.load_saved_records(device.aldb.status, records)
+    return record.mem_addr
+
+
+async def _load_devices(lock):
+    """Set up the devices and modem."""
+    async with lock:
+        if not devices.modem or devices.modem.address.id != "111111":
+            pass
+        modem = Hub("111111", 0x03, 51, 165, "Instoen modem")
+        devices.modem = modem
+        await load_devices(devices)
+        await asyncio.sleep(0.3)
+        _reset_devices(list(devices))
+
+
+class TestLinkManager(unittest.TestCase):
+    """Test the LinkManager class."""
+
+    def setUp(self) -> None:
+        """Set up the tests."""
+        set_log_levels(logger_topics=True, logger_messages="debug")
+
+    @async_case
+    async def test_modem_linking_mode(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        modem_link_topic = "ack.start_all_linking"
+        topics = [TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5)]
+        send_topics(topic_items=topics)
+        modem_resp, device_resp = await link_manager.async_enter_linking_mode(
+            link_mode=AllLinkMode.CONTROLLER, group=0
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.UNSENT
+
+    @async_case
+    async def test_linking_with_i2c_device(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        address = random_address()
+        modem = devices.modem
+        modem_link_topic = "ack.start_all_linking"
+
+        # Engine version topics
+        engine_version_ack = f"ack.{address.id}.get_insteon_engine_version.direct"
+        engine_version_direct_ack = (
+            f"{address.id}.get_insteon_engine_version.direct_ack"
+        )
+        engine_version_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        engine_version_kwargs = cmd_kwargs(
+            0x0D, int(EngineVersion.I2CS), None, modem.address
+        )
+
+        # Device link topics
+        device_link_ack = f"ack.{address.id}.enter_linking_mode.direct"
+        device_link_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        device_link_dir_ack = f"{address.id}.enter_linking_mode.direct_ack"
+        device_link_dir_ack_kwargs = cmd_kwargs(0x0D, 0x00, None, modem.address)
+
+        topics = [
+            TopicItem(engine_version_ack, engine_version_ack_kwargs, 0.5),
+            TopicItem(engine_version_direct_ack, engine_version_kwargs, 0.5),
+            TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5),
+            TopicItem(device_link_ack, device_link_ack_kwargs, 0.5),
+            TopicItem(device_link_dir_ack, device_link_dir_ack_kwargs, 0.5),
+        ]
+        send_topics(topic_items=topics)
+
+        async_send = AsyncMock(return_value=ResponseStatus.SUCCESS)
+        link_manager.EnterLinkingModeCommand.async_send = async_send
+
+        # A RuntimeWarning is raised when creating the EnterLinkingModeCommand due to the AsyncMock above
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        modem_resp, device_resp = await link_manager.async_enter_linking_mode(
+            link_mode=AllLinkMode.CONTROLLER, group=0, address=address
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.SUCCESS
+        assert async_send.call_args[1]["extended"]
+
+    @async_case
+    async def test_linking_with_i1_device(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        address = random_address()
+        modem = devices.modem
+        modem_link_topic = "ack.start_all_linking"
+
+        # Engine version topics
+        engine_version_ack = f"ack.{address.id}.get_insteon_engine_version.direct"
+        engine_version_direct_ack = (
+            f"{address.id}.get_insteon_engine_version.direct_ack"
+        )
+        engine_version_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        engine_version_kwargs = cmd_kwargs(
+            0x0D, int(EngineVersion.I1), None, modem.address
+        )
+
+        # Device link topics
+        device_link_ack = f"ack.{address.id}.enter_linking_mode.direct"
+        device_link_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        device_link_dir_ack = f"{address.id}.enter_linking_mode.direct_ack"
+        device_link_dir_ack_kwargs = cmd_kwargs(0x0D, 0x00, None, modem.address)
+
+        topics = [
+            TopicItem(engine_version_ack, engine_version_ack_kwargs, 0.5),
+            TopicItem(engine_version_direct_ack, engine_version_kwargs, 0.5),
+            TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5),
+            TopicItem(device_link_ack, device_link_ack_kwargs, 0.5),
+            TopicItem(device_link_dir_ack, device_link_dir_ack_kwargs, 0.5),
+        ]
+        send_topics(topic_items=topics)
+
+        async_send = AsyncMock(return_value=ResponseStatus.SUCCESS)
+        link_manager.EnterLinkingModeCommand.async_send = async_send
+
+        # A RuntimeWarning is raised when creating the EnterLinkingModeCommand due to the AsyncMock above
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        modem_resp, device_resp = await link_manager.async_enter_linking_mode(
+            link_mode=AllLinkMode.CONTROLLER, group=0, address=address
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.SUCCESS
+        assert not async_send.call_args[1]["extended"]
+
+    @async_case
+    async def test_linking_with_unknown_device_engine(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        address = random_address()
+        modem = devices.modem
+        modem_link_topic = "ack.start_all_linking"
+
+        # Engine version topics
+        engine_version_ack = f"ack.{address.id}.get_insteon_engine_version.direct"
+        engine_version_direct_ack = (
+            f"{address.id}.get_insteon_engine_version.direct_ack"
+        )
+        engine_version_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        # Easiest way to produce an unknown engine version response
+        engine_version_kwargs = cmd_kwargs(
+            0x0D, int(EngineVersion.UNKNOWN), None, modem.address
+        )
+
+        # Device link topics
+        device_link_ack = f"ack.{address.id}.enter_linking_mode.direct"
+        device_link_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        device_link_dir_ack = f"{address.id}.enter_linking_mode.direct_ack"
+        device_link_dir_ack_kwargs = cmd_kwargs(0x0D, 0x00, None, modem.address)
+
+        topics = [
+            TopicItem(engine_version_ack, engine_version_ack_kwargs, 0.5),
+            TopicItem(engine_version_direct_ack, engine_version_kwargs, 0.5),
+            TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5),
+            TopicItem(device_link_ack, device_link_ack_kwargs, 0.5),
+            TopicItem(device_link_dir_ack, device_link_dir_ack_kwargs, 0.5),
+        ]
+        send_topics(topic_items=topics)
+
+        async_send = AsyncMock(return_value=ResponseStatus.SUCCESS)
+        link_manager.EnterLinkingModeCommand.async_send = async_send
+
+        # A RuntimeWarning is raised when creating the EnterLinkingModeCommand due to the AsyncMock above
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        modem_resp, device_resp = await link_manager.async_enter_linking_mode(
+            link_mode=AllLinkMode.CONTROLLER, group=0, address=address
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.SUCCESS
+        assert async_send.call_args[1]["extended"]
+
+    @async_case
+    async def test_linking_with_device_engine_direct_nak(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        address = random_address()
+        modem = devices.modem
+        modem_link_topic = "ack.start_all_linking"
+
+        # Engine version topics
+        engine_version_ack = f"ack.{address.id}.get_insteon_engine_version.direct"
+        engine_version_direct_nak = (
+            f"{address.id}.get_insteon_engine_version.direct_nak"
+        )
+        engine_version_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        # Easiest way to produce an unknown engine version response
+        engine_version_kwargs = cmd_kwargs(
+            0x0D, int(ResponseStatus.DIRECT_NAK_ALDB), None, modem.address
+        )
+
+        # Device link topics
+        device_link_ack = f"ack.{address.id}.enter_linking_mode.direct"
+        device_link_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        device_link_dir_ack = f"{address.id}.enter_linking_mode.direct_ack"
+        device_link_dir_ack_kwargs = cmd_kwargs(0x0D, 0x00, None, modem.address)
+
+        topics = [
+            TopicItem(engine_version_ack, engine_version_ack_kwargs, 0.5),
+            TopicItem(engine_version_direct_nak, engine_version_kwargs, 0.5),
+            TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5),
+            TopicItem(device_link_ack, device_link_ack_kwargs, 0.5),
+            TopicItem(device_link_dir_ack, device_link_dir_ack_kwargs, 0.5),
+        ]
+        send_topics(topic_items=topics)
+
+        async_send = AsyncMock(return_value=ResponseStatus.SUCCESS)
+        link_manager.EnterLinkingModeCommand.async_send = async_send
+
+        # A RuntimeWarning is raised when creating the EnterLinkingModeCommand due to the AsyncMock above
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        modem_resp, device_resp = await link_manager.async_enter_linking_mode(
+            link_mode=AllLinkMode.CONTROLLER, group=0, address=address
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.SUCCESS
+        assert async_send.call_args[1]["extended"]
+
+    @async_case
+    async def test_linking_with_existing_device(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        address = devices["2b2b2b"].address
+        modem = devices.modem
+        modem_link_topic = "ack.start_all_linking"
+
+        # Device link topics
+        device_link_ack = f"ack.{address.id}.enter_linking_mode.direct"
+        device_link_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        device_link_dir_ack = f"{address.id}.enter_linking_mode.direct_ack"
+        device_link_dir_ack_kwargs = cmd_kwargs(0x0D, 0x00, None, modem.address)
+
+        topics = [
+            TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5),
+            TopicItem(device_link_ack, device_link_ack_kwargs, 0.5),
+            TopicItem(device_link_dir_ack, device_link_dir_ack_kwargs, 0.5),
+        ]
+        send_topics(topic_items=topics)
+
+        async_send = AsyncMock(return_value=ResponseStatus.SUCCESS)
+        link_manager.EnterLinkingModeCommand.async_send = async_send
+
+        # A RuntimeWarning is raised when creating the EnterLinkingModeCommand due to the AsyncMock above
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        modem_resp, device_resp = await link_manager.async_enter_linking_mode(
+            link_mode=AllLinkMode.CONTROLLER, group=0, address=address
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.SUCCESS
+        assert async_send.call_args[1]["extended"]
+
+    @async_case
+    async def test_linking_with_unresponsive_device(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        address = devices["2b2b2b"].address
+        modem = devices.modem
+        modem_link_topic = "ack.start_all_linking"
+
+        # Device link topics
+        device_link_ack = f"ack.{address.id}.enter_linking_mode.direct"
+        device_link_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        device_link_dir_ack = f"{address.id}.enter_linking_mode.direct_ack"
+        device_link_dir_ack_kwargs = cmd_kwargs(0x0D, 0x00, None, modem.address)
+
+        topics = [
+            TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5),
+            TopicItem(device_link_ack, device_link_ack_kwargs, 0.5),
+            TopicItem(device_link_dir_ack, device_link_dir_ack_kwargs, 0.5),
+        ]
+        send_topics(topic_items=topics)
+
+        async_send = AsyncMock(return_value=ResponseStatus.FAILURE)
+        link_manager.EnterLinkingModeCommand.async_send = async_send
+
+        # A RuntimeWarning is raised when creating the EnterLinkingModeCommand due to the AsyncMock above
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        modem_resp, device_resp = await link_manager.async_enter_linking_mode(
+            link_mode=AllLinkMode.CONTROLLER, group=0, address=address
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.FAILURE
+        assert async_send.call_count == 6
+
+    @async_case
+    async def test_modem_unlinking_mode(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        modem_link_topic = "ack.start_all_linking"
+        topics = [TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5)]
+        send_topics(topic_items=topics)
+        modem_resp, device_resp = await link_manager.async_enter_unlinking_mode(group=0)
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.UNSENT
+
+    @async_case
+    async def test_unlinking_with_i2c_device(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        address = random_address()
+        modem = devices.modem
+        modem_link_topic = "ack.start_all_linking"
+
+        # Engine version topics
+        engine_version_ack = f"ack.{address.id}.get_insteon_engine_version.direct"
+        engine_version_direct_ack = (
+            f"{address.id}.get_insteon_engine_version.direct_ack"
+        )
+        engine_version_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        engine_version_kwargs = cmd_kwargs(
+            0x0D, int(EngineVersion.I2CS), None, modem.address
+        )
+
+        # Device link topics
+        device_link_ack = f"ack.{address.id}.enter_unlinking_mode.direct"
+        device_link_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        device_link_dir_ack = f"{address.id}.enter_unlinking_mode.direct_ack"
+        device_link_dir_ack_kwargs = cmd_kwargs(0x0D, 0x00, None, modem.address)
+
+        topics = [
+            TopicItem(engine_version_ack, engine_version_ack_kwargs, 0.5),
+            TopicItem(engine_version_direct_ack, engine_version_kwargs, 0.5),
+            TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5),
+            TopicItem(device_link_ack, device_link_ack_kwargs, 0.5),
+            TopicItem(device_link_dir_ack, device_link_dir_ack_kwargs, 0.5),
+        ]
+        send_topics(topic_items=topics)
+
+        async_send = AsyncMock(return_value=ResponseStatus.SUCCESS)
+        link_manager.EnterUnlinkingModeCommand.async_send = async_send
+
+        # A RuntimeWarning is raised when creating the EnterLinkingModeCommand due to the AsyncMock above
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        modem_resp, device_resp = await link_manager.async_enter_unlinking_mode(
+            group=0, address=address
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.SUCCESS
+        assert async_send.call_args[1]["extended"]
+
+    @async_case
+    async def test_unlinking_with_i1_device(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        address = random_address()
+        modem = devices.modem
+        modem_link_topic = "ack.start_all_linking"
+
+        # Engine version topics
+        engine_version_ack = f"ack.{address.id}.get_insteon_engine_version.direct"
+        engine_version_direct_ack = (
+            f"{address.id}.get_insteon_engine_version.direct_ack"
+        )
+        engine_version_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        engine_version_kwargs = cmd_kwargs(
+            0x0D, int(EngineVersion.I1), None, modem.address
+        )
+
+        # Device link topics
+        device_link_ack = f"ack.{address.id}.enter_unlinking_mode.direct"
+        device_link_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        device_link_dir_ack = f"{address.id}.enter_unlinking_mode.direct_ack"
+        device_link_dir_ack_kwargs = cmd_kwargs(0x0D, 0x00, None, modem.address)
+
+        topics = [
+            TopicItem(engine_version_ack, engine_version_ack_kwargs, 0.5),
+            TopicItem(engine_version_direct_ack, engine_version_kwargs, 0.5),
+            TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5),
+            TopicItem(device_link_ack, device_link_ack_kwargs, 0.5),
+            TopicItem(device_link_dir_ack, device_link_dir_ack_kwargs, 0.5),
+        ]
+        send_topics(topic_items=topics)
+
+        async_send = AsyncMock(return_value=ResponseStatus.SUCCESS)
+        link_manager.EnterUnlinkingModeCommand.async_send = async_send
+
+        # A RuntimeWarning is raised when creating the EnterLinkingModeCommand due to the AsyncMock above
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        modem_resp, device_resp = await link_manager.async_enter_unlinking_mode(
+            group=0, address=address
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.SUCCESS
+        assert not async_send.call_args[1]["extended"]
+
+    @async_case
+    async def test_unlinking_with_unknown_device_engine(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        address = random_address()
+        modem = devices.modem
+        modem_link_topic = "ack.start_all_linking"
+
+        # Engine version topics
+        engine_version_ack = f"ack.{address.id}.get_insteon_engine_version.direct"
+        engine_version_direct_ack = (
+            f"{address.id}.get_insteon_engine_version.direct_ack"
+        )
+        engine_version_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        # Easiest way to produce an unknown engine version response
+        engine_version_kwargs = cmd_kwargs(
+            0x0D, int(EngineVersion.UNKNOWN), None, modem.address
+        )
+
+        # Device link topics
+        device_link_ack = f"ack.{address.id}.enter_unlinking_mode.direct"
+        device_link_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        device_link_dir_ack = f"{address.id}.enter_unlinking_mode.direct_ack"
+        device_link_dir_ack_kwargs = cmd_kwargs(0x0D, 0x00, None, modem.address)
+
+        topics = [
+            TopicItem(engine_version_ack, engine_version_ack_kwargs, 0.5),
+            TopicItem(engine_version_direct_ack, engine_version_kwargs, 0.5),
+            TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5),
+            TopicItem(device_link_ack, device_link_ack_kwargs, 0.5),
+            TopicItem(device_link_dir_ack, device_link_dir_ack_kwargs, 0.5),
+        ]
+        send_topics(topic_items=topics)
+
+        async_send = AsyncMock(return_value=ResponseStatus.SUCCESS)
+        link_manager.EnterUnlinkingModeCommand.async_send = async_send
+
+        # A RuntimeWarning is raised when creating the EnterLinkingModeCommand due to the AsyncMock above
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        modem_resp, device_resp = await link_manager.async_enter_unlinking_mode(
+            group=0, address=address
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.SUCCESS
+        assert async_send.call_args[1]["extended"]
+
+    @async_case
+    async def test_unlinking_with_device_engine_direct_nak(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        address = random_address()
+        modem = devices.modem
+        modem_link_topic = "ack.start_all_linking"
+
+        # Engine version topics
+        engine_version_ack = f"ack.{address.id}.get_insteon_engine_version.direct"
+        engine_version_direct_nak = (
+            f"{address.id}.get_insteon_engine_version.direct_nak"
+        )
+        engine_version_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        # Easiest way to produce an unknown engine version response
+        engine_version_kwargs = cmd_kwargs(
+            0x0D, int(ResponseStatus.DIRECT_NAK_ALDB), None, modem.address
+        )
+
+        # Device link topics
+        device_link_ack = f"ack.{address.id}.enter_unlinking_mode.direct"
+        device_link_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        device_link_dir_ack = f"{address.id}.enter_unlinking_mode.direct_ack"
+        device_link_dir_ack_kwargs = cmd_kwargs(0x0D, 0x00, None, modem.address)
+
+        topics = [
+            TopicItem(engine_version_ack, engine_version_ack_kwargs, 0.5),
+            TopicItem(engine_version_direct_nak, engine_version_kwargs, 0.5),
+            TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5),
+            TopicItem(device_link_ack, device_link_ack_kwargs, 0.5),
+            TopicItem(device_link_dir_ack, device_link_dir_ack_kwargs, 0.5),
+        ]
+        send_topics(topic_items=topics)
+
+        async_send = AsyncMock(return_value=ResponseStatus.SUCCESS)
+        link_manager.EnterUnlinkingModeCommand.async_send = async_send
+
+        # A RuntimeWarning is raised when creating the EnterLinkingModeCommand due to the AsyncMock above
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        modem_resp, device_resp = await link_manager.async_enter_unlinking_mode(
+            group=0, address=address
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.SUCCESS
+        assert async_send.call_args[1]["extended"]
+
+    @async_case
+    async def test_unlinking_with_existing_device(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        address = devices["2b2b2b"].address
+        modem = devices.modem
+        modem_link_topic = "ack.start_all_linking"
+
+        # Device link topics
+        device_link_ack = f"ack.{address.id}.enter_unlinking_mode.direct"
+        device_link_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        device_link_dir_ack = f"{address.id}.enter_unlinking_mode.direct_ack"
+        device_link_dir_ack_kwargs = cmd_kwargs(0x0D, 0x00, None, modem.address)
+
+        topics = [
+            TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5),
+            TopicItem(device_link_ack, device_link_ack_kwargs, 0.5),
+            TopicItem(device_link_dir_ack, device_link_dir_ack_kwargs, 0.5),
+        ]
+        send_topics(topic_items=topics)
+
+        async_send = AsyncMock(return_value=ResponseStatus.SUCCESS)
+        link_manager.EnterUnlinkingModeCommand.async_send = async_send
+
+        # A RuntimeWarning is raised when creating the EnterLinkingModeCommand due to the AsyncMock above
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        modem_resp, device_resp = await link_manager.async_enter_unlinking_mode(
+            group=0, address=address
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.SUCCESS
+        assert async_send.call_args[1]["extended"]
+
+    @async_case
+    async def test_unlinking_with_unresponsive_device(self):
+        """Test placing the modem into linking mode."""
+
+        await _load_devices(test_lock)
+        address = devices["2b2b2b"].address
+        modem = devices.modem
+        modem_link_topic = "ack.start_all_linking"
+
+        # Device link topics
+        device_link_ack = f"ack.{address.id}.enter_unlinking_mode.direct"
+        device_link_ack_kwargs = cmd_kwargs(0x0D, 0x00, None)
+        device_link_dir_ack = f"{address.id}.enter_unlinking_mode.direct_ack"
+        device_link_dir_ack_kwargs = cmd_kwargs(0x0D, 0x00, None, modem.address)
+
+        topics = [
+            TopicItem(modem_link_topic, {"link_mode": 0x01, "group": 0}, 0.5),
+            TopicItem(device_link_ack, device_link_ack_kwargs, 0.5),
+            TopicItem(device_link_dir_ack, device_link_dir_ack_kwargs, 0.5),
+        ]
+        send_topics(topic_items=topics)
+
+        async_send = AsyncMock(return_value=ResponseStatus.FAILURE)
+        link_manager.EnterUnlinkingModeCommand.async_send = async_send
+
+        # A RuntimeWarning is raised when creating the EnterLinkingModeCommand due to the AsyncMock above
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
+        modem_resp, device_resp = await link_manager.async_enter_unlinking_mode(
+            group=0, address=address
+        )
+        assert modem_resp == ResponseStatus.SUCCESS
+        assert device_resp == ResponseStatus.FAILURE
+        assert async_send.call_count == 6

--- a/tests/test_managers/test_scene_manager.py
+++ b/tests/test_managers/test_scene_manager.py
@@ -1,4 +1,5 @@
 """Test the device_link_manager class."""
+
 import asyncio
 import os
 from random import randint
@@ -27,6 +28,7 @@ from tests import load_devices, set_log_levels
 from tests.utils import async_case
 
 PWD = os.path.dirname(__file__)
+TEST_LOCK = asyncio.Lock()
 
 
 def _reset_devices(addresses):
@@ -69,8 +71,7 @@ class TestDeviceLinkManager(unittest.TestCase):
     @async_case
     async def test_save_load_scenes(self):
         """Test saving and loading scenes."""
-        patched_devices = DeviceManager()
-        with patch.object(pyinsteon, "devices", patched_devices):
+        async with TEST_LOCK:
             await self._test_save_load_scenes()
 
     async def _test_save_load_scenes(self):
@@ -96,8 +97,7 @@ class TestDeviceLinkManager(unittest.TestCase):
     @async_case
     async def test_add_scene(self):
         """Test adding a scene."""
-        patched_devices = DeviceManager()
-        with patch.object(pyinsteon, "devices", patched_devices):
+        async with TEST_LOCK:
             await self._test_add_scene()
 
     async def _test_add_scene(self):
@@ -270,8 +270,7 @@ class TestDeviceLinkManager(unittest.TestCase):
     @async_case
     async def test_delete_scene(self):
         """Test deleting a scene."""
-        patched_devices = DeviceManager()
-        with patch.object(pyinsteon, "devices", patched_devices):
+        async with TEST_LOCK:
             await self._test_delete_scene()
 
     async def _test_delete_scene(self):

--- a/tests/test_managers/test_status_manager.py
+++ b/tests/test_managers/test_status_manager.py
@@ -1,0 +1,122 @@
+"""Test the StatusManager class."""
+
+import asyncio
+from functools import partial
+import unittest
+from unittest.mock import AsyncMock
+
+from pyinsteon.constants import ResponseStatus
+from pyinsteon.managers.status_manager import StatusManager
+from pyinsteon.utils import subscribe_topic, unsubscribe_topic
+
+from .. import set_log_levels
+from ..utils import TopicItem, async_case, random_address, send_topics
+
+
+async def handle_status(handler, db_version, status):
+    """Handle the status call."""
+    await handler(db_version, status)
+
+
+def gen_topic_items(address, status_type, db_version, status):
+    """Generate a set of topics to respond correctly to a status request."""
+    ack_topic = f"ack.{address.id}.status_request.direct"
+    direct_ack_topic = f"{address.id}.any_topic.direct_ack"
+    return [
+        TopicItem(
+            ack_topic,
+            {"cmd1": 0x19, "cmd2": status_type, "user_data": None},
+            0.1,
+        ),
+        TopicItem(
+            direct_ack_topic,
+            {
+                "cmd1": db_version,
+                "cmd2": status,
+                "target": address.id,
+                "user_data": None,
+                "hops_left": 3,
+            },
+            0.5,
+        ),
+    ]
+
+
+def send_status_topics(address, status_type):
+    """Send the ack and direct_ack topics for a status message."""
+    topic_items = gen_topic_items(address, status_type, 0x22, 0x33)
+    send_topics(topic_items=topic_items)
+
+
+class TestStatusManager(unittest.TestCase):
+    """Test the StatusManager class."""
+
+    def setUp(self) -> None:
+        """Set up the test."""
+        set_log_levels(logger="debug", logger_topics=True)
+        subscribe_topic(send_status_topics, "send.status_request.direct")
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        """Unsubscribe to topic."""
+        unsubscribe_topic(send_status_topics, "send.status_request.direct")
+        return super().tearDown()
+
+    @async_case
+    async def test_single_status_call(self):
+        """Test a single status call."""
+        handler = AsyncMock(db_version=None, status=None)
+        address = random_address()
+        status_type = 0
+        status_manager = StatusManager(address=address)
+        status_manager.add_status_type(
+            status_type=status_type,
+            callback_function=partial(handle_status, handler=handler),
+        )
+
+        result = await status_manager.async_status()
+        await asyncio.sleep(0.01)
+        assert result == ResponseStatus.SUCCESS
+        assert handler.call_count == 1
+
+    @async_case
+    async def test_two_status_calls(self):
+        """Test a two status calls."""
+        handler = AsyncMock(db_version=None, status=None)
+        handler_1 = AsyncMock()
+        address = random_address()
+        status_type = 0
+        status_manager = StatusManager(address=address)
+        status_manager.add_status_type(
+            status_type=status_type,
+            callback_function=partial(handle_status, handler=handler),
+        )
+        status_type_1 = 1
+        status_manager.add_status_type(
+            status_type=status_type_1,
+            callback_function=partial(handle_status, handler=handler_1),
+        )
+
+        result = await status_manager.async_status()
+        await asyncio.sleep(1)
+        assert result == ResponseStatus.SUCCESS
+        assert handler.call_count == 1
+        assert handler_1.call_count == 1
+
+    @async_case
+    async def test_overlapping_status_calls(self):
+        """Test overlapping status request calls."""
+        handler = AsyncMock(db_version=None, status=None)
+        address = random_address()
+        status_type = 0
+        status_manager = StatusManager(address=address)
+        status_manager.add_status_type(
+            status_type=status_type,
+            callback_function=partial(handle_status, handler=handler),
+        )
+
+        asyncio.ensure_future(status_manager.async_status())
+        asyncio.ensure_future(status_manager.async_status())
+        await status_manager.async_status()
+        await asyncio.sleep(5)
+        assert handler.call_count == 2

--- a/tests/test_tools/tools_utils.py
+++ b/tests/test_tools/tools_utils.py
@@ -1,4 +1,5 @@
 """Utilities used to test tools functions."""
+
 import asyncio
 from io import StringIO
 import os
@@ -88,7 +89,7 @@ def log_file_lines(curr_dir):
     """Return the log file as an array."""
     log_file = os.path.join(curr_dir, LOG_FILE_NAME)
     assert os.path.isfile(log_file)
-    with open(log_file) as lfile:
+    with open(log_file, encoding="utf-8") as lfile:
         lines = lfile.readlines()
     return clean_buffer(lines, 48)
 
@@ -181,12 +182,12 @@ class MockDevices:
         device4 = create_device(ClimateControl_Thermostat, random_address(), 0x07, 0x05)
         self._devices[device4.address] = device4
 
-        # Do not set methods to AyncMock if python version < 3.8
-        if sys.version_info[0:2] < (3, 8):
+        # Do not set methods to AyncMock if python version < 3.9
+        if sys.version_info[0:2] < (3, 9):
             return
 
-        for addr in self._devices:
-            self._devices[addr].aldb.async_load = AsyncMock()
+        for _, device in self._devices.items():
+            device.aldb.async_load = AsyncMock()
 
         self.async_save = AsyncMock()
         self.async_load = AsyncMock()


### PR DESCRIPTION
Add On / Off at Ramp Rate broadcast message for I3 Dial dimming values
Fix status race conditions to prevent multiple status conditions from running in parallel
Improve remote linking
Fix name of ON/OFF events in the I3 KPL
Make python 3.12 the default version
Drop support for python 3.8
Fix some flaky tests