### PR TITLE
Fix #441 : Leak Sensor Heartbeat can never go to Problem state

### DIFF
--- a/pyinsteon/device_types/security_health_safety.py
+++ b/pyinsteon/device_types/security_health_safety.py
@@ -399,20 +399,10 @@ class SecurityHealthSafety_LeakSensor(BatteryDeviceBase, Device):
         wet_dry_mgr.subscribe_wet(wet_event.trigger)
 
         hb_mgr.subscribe(hb_event.trigger)
-        hb_mgr.subscribe_on(self._heartbeat_dry)
-        hb_mgr.subscribe_off(self._heartbeat_wet)
+        hb_mgr.subscribe(self._heartbeat_event)
 
-    def _heartbeat_dry(self, on_level):
-        """Receive heartbeat on/off message and create wet/dry status."""
-        self._groups[self.DRY_GROUP].value = True
-        self._groups[self.WET_GROUP].value = False
-        self._events[LEAK_DRY_EVENT].trigger(on_level)
-
-    def _heartbeat_wet(self, on_level):
-        """Receive heartbeat on/off message and create wet/dry status."""
-        self._groups[self.DRY_GROUP].value = False
-        self._groups[self.WET_GROUP].value = True
-        self._events[LEAK_WET_EVENT].trigger(on_level)
+    def _heartbeat_event(self, heartbeat: bool):
+        self._groups[self.HEARTBEAT_GROUP].value = heartbeat
 
     def _register_op_flags_and_props(self):
         # bit 0 = Cleanup Report

--- a/pyinsteon/events.py
+++ b/pyinsteon/events.py
@@ -95,7 +95,7 @@ class LowBatteryEvent(Event):
     def trigger(self, low_battery):
         """Trigger the event."""
         self._call_subscribers(
-            name=self._name, address=self._address.id, group=self._group, low_battery=low_battery
+            name=self._name, address=self._address.id, group=self._group
         )
 
 
@@ -106,7 +106,7 @@ class HeartbeatEvent(Event):
     def trigger(self, heartbeat):
         """Trigger the event."""
         self._call_subscribers(
-            name=self._name, address=self._address.id, group=self._group, heartbeat=heartbeat
+            name=self._name, address=self._address.id, group=self._group
         )
 
 
@@ -117,5 +117,5 @@ class WetDryEvent(Event):
     def trigger(self, dry):
         """Trigger the event."""
         self._call_subscribers(
-            name=self._name, address=self._address.id, group=self._group, dry=dry
+            name=self._name, address=self._address.id, group=self._group
         )

--- a/pyinsteon/events.py
+++ b/pyinsteon/events.py
@@ -95,7 +95,7 @@ class LowBatteryEvent(Event):
     def trigger(self, low_battery):
         """Trigger the event."""
         self._call_subscribers(
-            name=self._name, address=self._address.id, group=self._group
+            name=self._name, address=self._address.id, group=self._group, low_battery=low_battery
         )
 
 
@@ -106,7 +106,7 @@ class HeartbeatEvent(Event):
     def trigger(self, heartbeat):
         """Trigger the event."""
         self._call_subscribers(
-            name=self._name, address=self._address.id, group=self._group
+            name=self._name, address=self._address.id, group=self._group, heartbeat=heartbeat
         )
 
 
@@ -117,5 +117,5 @@ class WetDryEvent(Event):
     def trigger(self, dry):
         """Trigger the event."""
         self._call_subscribers(
-            name=self._name, address=self._address.id, group=self._group
+            name=self._name, address=self._address.id, group=self._group, dry=dry
         )

--- a/pyinsteon/managers/heartbeat_manager.py
+++ b/pyinsteon/managers/heartbeat_manager.py
@@ -74,8 +74,10 @@ class HeartbeatManager(SubscriberBase):
         """Check if a heartbeat as arrived since max_duration."""
         td_last_heartbeat = datetime.now() - self._last_heartbeat
         if td_last_heartbeat > timedelta(minutes=self._max_duration):
+            # Heartbeat timeout expired, call subscribers with missed heartbeat
             self._call_subscribers(heartbeat=True)
         else:
+            # Heartbeat received within max_duration, call subscribers with received heartbeat
             self._call_subscribers(heartbeat=False)
         self._schedule_next_check()
 

--- a/pyinsteon/managers/heartbeat_manager.py
+++ b/pyinsteon/managers/heartbeat_manager.py
@@ -22,7 +22,7 @@ class HeartbeatManager(SubscriberBase):
             self._call_subscribers(on_level=on_level)
 
     # The default heartbeat interval is 24 hours, but can vary, so use 30 hours as a default max duration to trigger a missed heartbeat
-    def __init__(self, address, group, max_duration=((24 + 6) * 60)):
+    def __init__(self, address, group, max_duration=(24 + 6) * 60):
         """Init the HeartbeatManager class."""
         self._address = Address(address)
         self._group = group

--- a/pyinsteon/managers/heartbeat_manager.py
+++ b/pyinsteon/managers/heartbeat_manager.py
@@ -21,7 +21,8 @@ class HeartbeatManager(SubscriberBase):
             """Call subscribers to the event."""
             self._call_subscribers(on_level=on_level)
 
-    def __init__(self, address, group, max_duration=1275):
+    # The default heartbeat interval is 24 hours, but can vary, so use 30 hours as a default max duration to trigger a missed heartbeat
+    def __init__(self, address, group, max_duration=((24 + 6) * 60)):
         """Init the HeartbeatManager class."""
         self._address = Address(address)
         self._group = group


### PR DESCRIPTION
Class SecurityHealthSafety_LeakSensor doesn't use the heartbeat parameter that comes in the notification from the heartbeat manager.

The heartbeat state for the leak sensor will stay "off" regardless of a missed heartbeat.

Also, the leak sensor heartbeat Insteon message is only a "on" message, there is no corresponding heartbeat "off" message.

This is an important bug. Currently you will never know the heartbeat has been missed. Since this is the only way to know a leak sensor battery is ok and the sensor is operating, the battery could be dead for months and it would still report the heartbeat (from the manager check).

The fix is to use the heartbeat parameter when setting the heartbeat group value.