### PR TITLE
Multi-modem support: InsteonStack and address-based routing

### DIFF
--- a/pyinsteon/__init__.py
+++ b/pyinsteon/__init__.py
@@ -7,6 +7,7 @@ from pubsub import pub
 
 from .address import Address
 from .handlers.from_device.x10_received import X10Received
+from .insteon_stack import InsteonStack  # noqa: F401
 from .listener_exception_handler import ListenerExceptionHandler
 from .managers.device_link_manager import DeviceLinkManager
 from .managers.device_manager import DeviceManager
@@ -26,6 +27,13 @@ X10_RECEIVED_HANDLER = X10Received()
 devices = DeviceManager()
 link_manager = DeviceLinkManager(devices)
 subscribe_topic(async_add_default_links, ADD_DEFAULT_LINKS)
+
+# Backward-compatible default stack: the module-level API (async_connect,
+# devices, link_manager) is backed by this stack under modem_id "default".
+# Additional modems are created via pyinsteon.insteon_stack.InsteonStack.
+_default_stack = InsteonStack(
+    modem_id="default", devices=devices, link_manager=link_manager
+)
 
 
 async def async_connect(
@@ -51,7 +59,7 @@ async def async_connect(
 
     """
     try:
-        modem = await async_modem_connect(
+        await _default_stack.async_connect(
             device=device,
             host=host,
             port=port,
@@ -62,9 +70,6 @@ async def async_connect(
         )
     except ConnectionError as err:
         raise ConnectionError from err
-    devices.modem = modem
-    devices.id_manager.start()
-    await devices.modem.async_get_configuration()
     return devices
 
 

--- a/pyinsteon/insteon_stack.py
+++ b/pyinsteon/insteon_stack.py
@@ -162,7 +162,12 @@ class InsteonStack:
         outbound_write_manager.assign_address(modem.address, self._modem_id)
         self._sync_ownership()
         self._devices.id_manager.start()
-        await self._devices.modem.async_get_configuration()
+        # Modem-scoped commands (e.g. get_im_configuration) must run under
+        # MODEM_CONTEXT. With multiple registered modems, messages without a
+        # context or destination address are dropped — which hangs second-hub
+        # setup forever waiting for a response that never comes.
+        with self.modem_context():
+            await self._devices.modem.async_get_configuration()
         return self
 
     async def async_close(self):

--- a/pyinsteon/insteon_stack.py
+++ b/pyinsteon/insteon_stack.py
@@ -1,0 +1,210 @@
+"""Per-modem container for multi-modem Insteon deployments.
+
+An ``InsteonStack`` bundles everything scoped to one physical modem
+(PLM or Hub): its connection, its ``DeviceManager``, its link manager,
+and its saved-device file. It also keeps the outbound write router's
+address-ownership map in sync as devices are added and removed, so
+direct messages always egress the correct modem.
+
+Single-modem usage is unchanged: the module-level ``pyinsteon.devices``
+and ``pyinsteon.async_connect`` are backed by a default stack.
+
+Multi-modem usage:
+
+    from pyinsteon import async_connect, devices
+    from pyinsteon.insteon_stack import InsteonStack
+
+    # Modem 1 (legacy API, modem_id "default")
+    await async_connect(host="192.168.1.10", username=..., password=...)
+
+    # Modem 2
+    barn = InsteonStack("barn")
+    await barn.async_connect(host="192.168.1.20", username=..., password=...)
+    await barn.async_load(workdir="/config")  # insteon_devices_barn.json
+"""
+import asyncio
+from contextlib import contextmanager
+import logging
+
+from .constants import DeviceAction
+from .managers.device_link_manager import DeviceLinkManager
+from .managers.device_manager import DeviceManager
+from .protocol import async_modem_connect
+from .protocol.messages.outbound import (
+    DEVICE_MANAGER_CONTEXT,
+    MODEM_CONTEXT,
+    outbound_write_manager,
+)
+from .utils import modem_topic_prefix, subscribe_topic, unsubscribe_topic
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_MODEM_ID = "default"
+LEGACY_DEVICE_FILE = "insteon_devices.json"
+
+
+class InsteonStack:
+    """All state for one Insteon modem: connection, devices, links, routing."""
+
+    def __init__(self, modem_id=DEFAULT_MODEM_ID, devices=None, link_manager=None):
+        """Init the InsteonStack.
+
+        Parameters:
+            modem_id: Routing identity for this modem. Must be unique per
+                stack within the process.
+            devices: Optional existing DeviceManager to adopt (used by the
+                module-level default stack for backward compatibility).
+            link_manager: Optional existing DeviceLinkManager to adopt.
+        """
+        self._modem_id = modem_id
+        self._devices = devices if devices is not None else DeviceManager()
+        self._link_manager = (
+            link_manager
+            if link_manager is not None
+            else DeviceLinkManager(self._devices)
+        )
+        self._devices.subscribe(self._device_list_changed)
+
+    @property
+    def modem_id(self):
+        """Return the routing identity of this stack's modem."""
+        return self._modem_id
+
+    @property
+    def devices(self):
+        """Return this stack's DeviceManager."""
+        return self._devices
+
+    @property
+    def link_manager(self):
+        """Return this stack's DeviceLinkManager."""
+        return self._link_manager
+
+    @property
+    def modem(self):
+        """Return this stack's modem device (None before connect)."""
+        return self._devices.modem
+
+    @contextmanager
+    def modem_context(self):
+        """Route modem-scoped outbound messages to this stack's modem.
+
+        Use around pyinsteon module-level operations that address the
+        modem rather than a device (all-linking, X10 broadcasts, scene
+        triggers, modem ALDB access).
+        """
+        token = MODEM_CONTEXT.set(self._modem_id)
+        mgr_token = DEVICE_MANAGER_CONTEXT.set(self._devices)
+        try:
+            yield self
+        finally:
+            DEVICE_MANAGER_CONTEXT.reset(mgr_token)
+            MODEM_CONTEXT.reset(token)
+
+    @property
+    def topic_prefix(self):
+        """Return this stack's modem-scoped pubsub topic prefix."""
+        return modem_topic_prefix(self._modem_id)
+
+    def subscribe_connection_made(self, callback):
+        """Subscribe to this modem's connection.made events."""
+        subscribe_topic(callback, f"{self.topic_prefix}.connection.made")
+
+    def subscribe_connection_failed(self, callback):
+        """Subscribe to this modem's connection.failed events."""
+        subscribe_topic(callback, f"{self.topic_prefix}.connection.failed")
+
+    def unsubscribe_connection_made(self, callback):
+        """Unsubscribe from this modem's connection.made events."""
+        unsubscribe_topic(callback, f"{self.topic_prefix}.connection.made")
+
+    def unsubscribe_connection_failed(self, callback):
+        """Unsubscribe from this modem's connection.failed events."""
+        unsubscribe_topic(callback, f"{self.topic_prefix}.connection.failed")
+
+    @property
+    def device_file(self):
+        """Return the saved-device filename for this stack.
+
+        The default stack keeps the legacy filename so existing
+        single-modem deployments load their cache unchanged.
+        """
+        if self._modem_id == DEFAULT_MODEM_ID:
+            return LEGACY_DEVICE_FILE
+        return f"insteon_devices_{self._modem_id}.json"
+
+    async def async_connect(
+        self,
+        device=None,
+        host=None,
+        port=None,
+        username=None,
+        password=None,
+        hub_version=2,
+        **kwargs,
+    ):
+        """Connect this stack to its Insteon modem.
+
+        Accepts the same parameters as ``pyinsteon.async_connect`` and
+        returns this stack.
+        """
+        modem = await async_modem_connect(
+            device=device,
+            host=host,
+            port=port,
+            username=username,
+            password=password,
+            hub_version=hub_version,
+            modem_id=self._modem_id,
+            **kwargs,
+        )
+        self._devices.modem = modem
+        outbound_write_manager.assign_address(modem.address, self._modem_id)
+        self._sync_ownership()
+        self._devices.id_manager.start()
+        await self._devices.modem.async_get_configuration()
+        return self
+
+    async def async_close(self):
+        """Close this stack's connection and stop its tasks."""
+        with self.modem_context():
+            if self._devices.modem is not None:
+                await self._devices.modem.async_close()
+        for addr in self._devices:
+            if self._devices[addr].is_battery:
+                self._devices[addr].close()
+        self._devices.id_manager.close()
+        outbound_write_manager.unregister_modem(self._modem_id)
+        await asyncio.sleep(0.1)
+
+    async def async_load(self, workdir="", id_devices=1, load_modem_aldb=1):
+        """Load this stack's devices from its per-modem saved-device file."""
+        with self.modem_context():
+            result = await self._devices.async_load(
+                workdir=workdir,
+                id_devices=id_devices,
+                load_modem_aldb=load_modem_aldb,
+                device_file=self.device_file,
+            )
+        self._sync_ownership()
+        return result
+
+    async def async_save(self, workdir):
+        """Save this stack's devices to its per-modem saved-device file."""
+        return await self._devices.async_save(
+            workdir=workdir, device_file=self.device_file
+        )
+
+    def _sync_ownership(self):
+        """Assign every known device address to this stack's modem."""
+        for addr in self._devices:
+            outbound_write_manager.assign_address(addr, self._modem_id)
+
+    def _device_list_changed(self, address, action):
+        """Keep router ownership in sync with device list changes."""
+        if address is None:
+            return
+        if action == DeviceAction.ADDED:
+            outbound_write_manager.assign_address(address, self._modem_id)
+        elif action == DeviceAction.REMOVED:
+            outbound_write_manager.unassign_address(address)

--- a/pyinsteon/managers/device_id_manager.py
+++ b/pyinsteon/managers/device_id_manager.py
@@ -47,7 +47,11 @@ class DeviceIdManager(SubscriberBase):
 
     def __init__(self):
         """Init the DeviceIdManager class."""
-        super().__init__(subscriber_topic="device_id")
+        # Instance-unique subtopic: each DeviceManager owns its own
+        # DeviceIdManager; identification events must not propagate to
+        # other managers (multi-modem). Parent-topic subscribers to
+        # "device_id" still receive these events.
+        super().__init__(subscriber_topic=f"device_id.instance_{id(self):x}")
         self._unknown_devices = []
         self._device_ids = {}
 

--- a/pyinsteon/managers/device_manager.py
+++ b/pyinsteon/managers/device_manager.py
@@ -33,7 +33,13 @@ class DeviceManager(SubscriberBase):
 
     def __init__(self):
         """Init the DeviceManager class."""
-        super().__init__(subscriber_topic=DEVICE_LIST_CHANGED)
+        # Instance-unique subtopic: multiple DeviceManagers (multi-modem)
+        # must not receive each other's add/remove events. Subscribers to
+        # the parent DEVICE_LIST_CHANGED topic still receive these events
+        # (pypubsub parent-topic semantics), preserving back-compat.
+        super().__init__(
+            subscriber_topic=f"{DEVICE_LIST_CHANGED}.instance_{id(self):x}"
+        )
         self._devices: dict[Address, Device] = {}
         self._modem = None
         self._id_manager = DeviceIdManager()
@@ -298,7 +304,7 @@ class DeviceManager(SubscriberBase):
         """Close the device ID listener."""
         self._id_manager.close()
 
-    async def async_load(self, workdir="", id_devices=1, load_modem_aldb=1):
+    async def async_load(self, workdir="", id_devices=1, load_modem_aldb=1, device_file=None):
         """Load devices from the `insteon_devices.yaml` file and device overrides.
 
         Parameters:
@@ -321,7 +327,9 @@ class DeviceManager(SubscriberBase):
         """
         if workdir:
             async with self._loading_saved_lock:
-                saved_devices_manager = SavedDeviceManager(workdir, self.modem)
+                saved_devices_manager = SavedDeviceManager(
+                    workdir, self.modem, device_file=device_file
+                )
                 devices = await saved_devices_manager.async_load()
                 for address in devices:
                     self[address] = devices[address]
@@ -345,9 +353,11 @@ class DeviceManager(SubscriberBase):
             id_all = id_devices == 2
             await self._id_manager.async_id_devices(refresh=id_all)
 
-    async def async_save(self, workdir):
+    async def async_save(self, workdir, device_file=None):
         """Save devices to a device information file."""
-        saved_devices_manager = SavedDeviceManager(workdir, self.modem)
+        saved_devices_manager = SavedDeviceManager(
+            workdir, self.modem, device_file=device_file
+        )
         await saved_devices_manager.async_save(self._devices)
 
     async def _async_device_identified(

--- a/pyinsteon/managers/saved_devices_manager.py
+++ b/pyinsteon/managers/saved_devices_manager.py
@@ -221,10 +221,11 @@ def _convert_old_aldb(old_aldb):
 class SavedDeviceManager:
     """Manage saving and restoring devices from JSON."""
 
-    def __init__(self, workdir, modem):
+    def __init__(self, workdir, modem, device_file=None):
         """Init the SavedDeviceManager class."""
         self._workdir = workdir
         self._modem = modem
+        self._device_file_name = device_file if device_file else DEVICE_INFO_FILE
 
     async def async_save(self, device_list: dict):
         """Save all devices to the `insteon_devices.json` file for faster loading."""
@@ -273,7 +274,7 @@ class SavedDeviceManager:
             return saved_devices
 
         try:
-            device_file = path.join(self._workdir, DEVICE_INFO_FILE)
+            device_file = path.join(self._workdir, self._device_file_name)
             async with aiofiles.open(device_file, "r") as afp:
                 json_file = ""
                 json_file = await afp.read()
@@ -288,7 +289,7 @@ class SavedDeviceManager:
 
     async def _write_saved_devices(self, device_list):
         _LOGGER.debug("Writing %d devices to save file", len(device_list))
-        device_file = path.join(self._workdir, DEVICE_INFO_FILE)
+        device_file = path.join(self._workdir, self._device_file_name)
         try:
             async with aiofiles.open(device_file, "w") as afp:
                 out_json = json.dumps(device_list, indent=2)

--- a/pyinsteon/managers/scene_manager.py
+++ b/pyinsteon/managers/scene_manager.py
@@ -9,7 +9,22 @@ from typing import Dict, Union
 import aiofiles
 import voluptuous as vol
 
-from .. import devices
+from ..protocol.messages.outbound import DEVICE_MANAGER_CONTEXT
+
+
+def _devices():
+    """Return the DeviceManager for the active modem context.
+
+    Falls back to the module-level default manager, preserving
+    single-modem behavior. Multi-modem callers wrap scene operations
+    in InsteonStack.modem_context().
+    """
+    ctx_mgr = DEVICE_MANAGER_CONTEXT.get()
+    if ctx_mgr is not None:
+        return ctx_mgr
+    from .. import devices  # pylint: disable=import-outside-toplevel
+
+    return devices
 from ..address import Address
 from ..constants import ResponseStatus
 from ..handlers.send_all_link_off import SendAllLinkOffCommandHandler
@@ -47,7 +62,7 @@ async def _get_scene_device_status(group: int):
     """Get the status of the devices in a scene."""
     scene = await async_get_scene(group)
     for addr in scene["devices"]:
-        device = devices[addr]
+        device = _devices()[addr]
         if device:
             await device.async_status()
 
@@ -71,12 +86,12 @@ async def async_get_scenes(work_dir=None):
     scenes: Dict[Group, Dict[str, Union[Dict[ResponderAddress, LinkInfo], str]]] = {}
     if work_dir:
         await async_load_scene_names(work_dir=work_dir)
-    for addr in devices:
-        device = devices[addr]
-        if device == devices.modem:
+    for addr in _devices():
+        device = _devices()[addr]
+        if device == _devices().modem:
             continue
         for rec in device.aldb.find(
-            target=devices.modem.address, is_controller=False, in_use=True
+            target=_devices().modem.address, is_controller=False, in_use=True
         ):
             if rec.group == 0:
                 continue
@@ -91,7 +106,7 @@ async def async_get_scenes(work_dir=None):
             if not scene["devices"].get(device.address):
                 scene["devices"][device.address] = []
             has_controller = False
-            for _ in devices.modem.aldb.find(
+            for _ in _devices().modem.aldb.find(
                 target=device.address, group=rec.group, is_controller=True, in_use=True
             ):
                 has_controller = True
@@ -110,12 +125,12 @@ async def async_get_scene(scene_num: int, work_dir: str = None):
     scene["name"] = _scene_names.get(scene_num, f"Insteon Scene {scene_num}")
     scene["group"] = scene_num
     scene["devices"] = {}
-    for addr in devices:
-        device = devices[addr]
-        if device == devices.modem:
+    for addr in _devices():
+        device = _devices()[addr]
+        if device == _devices().modem:
             continue
         for rec in device.aldb.find(
-            target=devices.modem.address,
+            target=_devices().modem.address,
             is_controller=False,
             in_use=True,
             group=scene_num,
@@ -125,7 +140,7 @@ async def async_get_scene(scene_num: int, work_dir: str = None):
             if not scene["devices"].get(device.address):
                 scene["devices"][device.address] = []
             has_controller = False
-            for _ in devices.modem.aldb.find(
+            for _ in _devices().modem.aldb.find(
                 target=device.address, group=rec.group, is_controller=True, in_use=True
             ):
                 has_controller = True
@@ -177,8 +192,8 @@ async def async_add_device_to_scene(
     delay_write: bool = False,
 ):
     """Add a device to a scene."""
-    device = devices[address]
-    modem = devices.modem
+    device = _devices()[address]
+    modem = _devices().modem
     device.aldb.add(
         group=scene_num,
         target=modem.address,
@@ -207,8 +222,8 @@ async def async_remove_device_from_scene(
 ):
     """Remove a device from a scene."""
 
-    device = devices[address]
-    modem = devices.modem
+    device = _devices()[address]
+    modem = _devices().modem
     for rec in device.aldb.find(
         group=scene_num, target=modem.address, is_controller=False, in_use=True
     ):
@@ -248,10 +263,10 @@ async def async_add_or_update_scene(
 
     # Add the devices from device_info param
     for link in links:
-        device = devices[link["address"]]
+        device = _devices()[link["address"]]
         device.aldb.add(
             group=scene_num,
-            target=devices.modem.address,
+            target=_devices().modem.address,
             controller=False,
             data1=link["data1"],
             data2=link["data2"],
@@ -259,7 +274,7 @@ async def async_add_or_update_scene(
         )
         if device not in updated_devices:
             updated_devices.append(device)
-        devices.modem.aldb.add(
+        _devices().modem.aldb.add(
             group=scene_num,
             target=device.address,
             controller=True,
@@ -300,25 +315,25 @@ def _remove_scene_links(scene_num: int, scene_data):
     if scene_data:
         curr_device_info = scene_data["devices"]
         for addr, info_list in curr_device_info.items():
-            device = devices[addr]
+            device = _devices()[addr]
             for info in info_list:
                 for rec in device.aldb.find(
                     is_controller=False,
                     group=scene_num,
-                    target=devices.modem.address,
+                    target=_devices().modem.address,
                     data3=info.data3,
                     in_use=True,
                 ):
                     device.aldb.remove(rec.mem_addr)
                     if device not in updated_devices:
                         updated_devices.append(device)
-                for modem_rec in devices.modem.aldb.find(
+                for modem_rec in _devices().modem.aldb.find(
                     is_controller=True,
                     target=device.address,
                     group=scene_num,
                     in_use=True,
                 ):
-                    devices.modem.aldb.remove(modem_rec.mem_addr)
+                    _devices().modem.aldb.remove(modem_rec.mem_addr)
     return updated_devices
 
 
@@ -329,7 +344,7 @@ async def _async_write_scene_link_changes(device_list):
         _, failed = await device.aldb.async_write()
         result = ResponseStatus.FAILURE if failed else ResponseStatus.SUCCESS
         results.append(result)
-    _, failed = await devices.modem.aldb.async_write()
+    _, failed = await _devices().modem.aldb.async_write()
     result = ResponseStatus.FAILURE if failed else ResponseStatus.SUCCESS
     results.append(result)
     return multiple_status(*results)

--- a/pyinsteon/protocol/__init__.py
+++ b/pyinsteon/protocol/__init__.py
@@ -7,6 +7,7 @@ import logging
 from ..constants import ResponseStatus
 from ..handlers.get_im_info import GetImInfoHandler
 from ..managers.device_id_manager import DeviceId
+from .messages.outbound import MODEM_CONTEXT
 from ..managers.utils import create_device
 from .http_transport import async_connect_http
 from .mock.mock_transport import async_connect_mock
@@ -24,6 +25,7 @@ async def async_modem_connect(
     password=None,
     hub_version=2,
     mock=False,
+    modem_id=None,
 ):
     """Connect to the Insteon Modem.
 
@@ -75,11 +77,13 @@ async def async_modem_connect(
     else:
         connect_method = partial(async_connect_socket, **{"host": host, "port": port})
 
-    protocol = Protocol(connect_method=connect_method)
+    protocol = Protocol(connect_method=connect_method, modem_id=modem_id)
+    context_token = MODEM_CONTEXT.set(protocol.modem_id)
 
     try:
         await protocol.async_connect(retry=False)
     except ConnectionError as ex:
+        MODEM_CONTEXT.reset(context_token)
         raise ConnectionError("Modem did not respond connection request") from ex
 
     get_im_info = GetImInfoHandler()
@@ -93,8 +97,10 @@ async def async_modem_connect(
 
     # Wait for a max of 60 seconds for the modem to respond
     if device_id is None and not await async_test_device_id():
+        MODEM_CONTEXT.reset(context_token)
         raise ConnectionError("Modem did not respond to ID request")
 
+    MODEM_CONTEXT.reset(context_token)
     modem = create_device(device_id)
     modem.protocol = protocol
     modem.transport = transport

--- a/pyinsteon/protocol/messages/outbound.py
+++ b/pyinsteon/protocol/messages/outbound.py
@@ -1,5 +1,6 @@
 """Create outbound messages."""
 
+from contextvars import ContextVar
 import logging
 
 from . import MessageBase
@@ -57,28 +58,124 @@ def register_outbound_handlers():
         subscribe_topic(func, topic)
 
 
+MODEM_CONTEXT: ContextVar = ContextVar("insteon_modem_context", default=None)
+DEVICE_MANAGER_CONTEXT: ContextVar = ContextVar(
+    "insteon_device_manager_context", default=None
+)
+
+
 class OutboundWriteManager:
-    """Ourbound write manager."""
+    """Outbound write manager with address-based modem routing.
+
+    Supports multiple simultaneously connected modems. Direct messages
+    (those carrying a destination ``address``) are routed to the modem
+    that owns that address. Ownership is declared via ``assign_address``.
+
+    Backward compatibility: the legacy ``protocol_write`` property remains
+    the default write target. Single-modem deployments that never call
+    ``register_modem`` behave exactly as before.
+
+    Routing policy for ``write``:
+        1. Destination address has an assigned, registered modem -> route
+           to that modem.
+        2. Otherwise, MODEM_CONTEXT contextvar names a registered modem
+           (set by InsteonStack operations for modem-scoped commands such
+           as the connect handshake, all-linking, X10 broadcasts) ->
+           route to it.
+        3. Otherwise, legacy ``protocol_write`` is set -> route there.
+        4. Otherwise, exactly one modem is registered -> route to it.
+        5. Otherwise, multiple modems and unresolvable destination ->
+           log an error and DROP (never broadcast to all modems).
+        6. Nothing registered at all -> raise AttributeError (legacy
+           contract).
+    """
 
     def __init__(self):
         """Init the OutboundWriteManager class."""
         self._protocol_write = None
+        self._modem_writers = {}
+        self._address_owner = {}
 
     @property
     def protocol_write(self):
-        """Return the write method of the protocol."""
+        """Return the default (legacy) write method of the protocol."""
         return self._protocol_write
 
     @protocol_write.setter
     def protocol_write(self, value):
-        """Set the write method of the protocol."""
+        """Set the default (legacy) write method of the protocol."""
         self._protocol_write = value
 
+    def register_modem(self, modem_id, write_fn):
+        """Register a modem's write function under a modem id."""
+        self._modem_writers[modem_id] = write_fn
+
+    def unregister_modem(self, modem_id):
+        """Unregister a modem and release its address assignments."""
+        self._modem_writers.pop(modem_id, None)
+        self._address_owner = {
+            addr: owner
+            for addr, owner in self._address_owner.items()
+            if owner != modem_id
+        }
+
+    def assign_address(self, address, modem_id):
+        """Assign ownership of a device address to a modem."""
+        self._address_owner[self._addr_key(address)] = modem_id
+
+    def unassign_address(self, address):
+        """Remove ownership of a device address."""
+        self._address_owner.pop(self._addr_key(address), None)
+
+    @staticmethod
+    def _addr_key(address):
+        """Normalize an address to its routing key."""
+        from ...address import Address  # pylint: disable=import-outside-toplevel
+
+        return str(Address(address))
+
+    def _resolve(self, msg):
+        """Return the write function for a message per routing policy."""
+        dest = getattr(msg, "address", None)
+        if dest is not None:
+            owner = self._address_owner.get(self._addr_key(dest))
+            if owner is not None:
+                write_fn = self._modem_writers.get(owner)
+                if write_fn is not None:
+                    return write_fn
+                _LOGGER.error(
+                    "Address %s assigned to unregistered modem %s; message dropped",
+                    dest,
+                    owner,
+                )
+                return None
+        context_modem = MODEM_CONTEXT.get()
+        if context_modem is not None:
+            write_fn = self._modem_writers.get(context_modem)
+            if write_fn is not None:
+                return write_fn
+            _LOGGER.error(
+                "Modem context %s is not a registered modem; falling through",
+                context_modem,
+            )
+        if self._protocol_write is not None:
+            return self._protocol_write
+        if len(self._modem_writers) == 1:
+            return next(iter(self._modem_writers.values()))
+        if self._modem_writers:
+            _LOGGER.error(
+                "No modem owns destination %s and no default modem is set; "
+                "message dropped (will not broadcast to all modems)",
+                getattr(msg, "address", "<modem-scoped>"),
+            )
+            return None
+        raise AttributeError
+
     def write(self, msg, priority):
-        """Write to the protocol."""
-        if self._protocol_write is None:
-            raise AttributeError
-        self._protocol_write(msg=msg, priority=priority)
+        """Write to the owning modem's protocol."""
+        write_fn = self._resolve(msg)
+        if write_fn is not None:
+            write_fn(msg=msg, priority=priority)
 
 
 outbound_write_manager = OutboundWriteManager()

--- a/pyinsteon/protocol/protocol.py
+++ b/pyinsteon/protocol/protocol.py
@@ -8,7 +8,7 @@ from typing import Union
 
 from ..address import Address
 from ..constants import AckNak
-from ..utils import log_error, publish_topic
+from ..utils import log_error, modem_topic_prefix, publish_topic
 from .command_to_msg import register_command_handlers
 from .messages.inbound import create
 from .messages.outbound import outbound_write_manager, register_outbound_handlers
@@ -35,8 +35,39 @@ def _get_addresses_in_msg(msg):
     return addresses
 
 
+def _is_modem_scoped(topic):
+    """Return True if a topic is modem-scoped (not device-address-scoped).
+
+    Device topics begin with a device address (e.g. "1a2b3c.on.direct"),
+    optionally behind an "ack"/"nak"/"handler" prefix. Anything else
+    (connection state, X10, all-link events, IM info/config) is scoped to
+    the modem that produced it and must be distinguishable per modem.
+    """
+    segments = topic.split(".")
+    if segments and segments[0] in ("ack", "nak", "handler"):
+        segments = segments[1:]
+    if not segments:
+        return True
+    try:
+        Address(segments[0])
+    except ValueError:
+        return True
+    return False
+
+
+def publish_modem_topic(modem_id, topic, **kwargs):
+    """Publish a topic in both legacy and modem-namespaced form.
+
+    The unprefixed topic preserves backward compatibility for all
+    existing subscribers. The modem-prefixed duplicate lets multi-modem
+    consumers attribute the event to a specific modem.
+    """
+    publish_topic(f"{modem_topic_prefix(modem_id)}.{topic}", **kwargs)
+    publish_topic(topic, **kwargs)
+
+
 # pylint: disable=broad-except
-async def _publish_message(msg):
+async def _publish_message(msg, modem_id="default"):
     """Convert an inbound message to a topic and publish to listeners."""
     _LOGGER_MSG.debug("RX: %s", repr(msg))
     if (_LOGGER_MSG.level == 0 or _LOGGER_MSG.level > logging.DEBUG) and (
@@ -49,7 +80,10 @@ async def _publish_message(msg):
     kwargs = {}
     try:
         for topic, kwargs in convert_to_topic(msg):
-            publish_topic(topic, **kwargs)
+            if _is_modem_scoped(topic):
+                publish_modem_topic(modem_id, topic, **kwargs)
+            else:
+                publish_topic(topic, **kwargs)
     except ValueError:
         # No topic was found for this message
         _LOGGER.debug("No topic found for message %r", msg)
@@ -69,7 +103,7 @@ class TransportStatus(Enum):
 class Protocol(asyncio.Protocol):
     """Serial protocol to perform async I/O with the PLM."""
 
-    def __init__(self, connect_method, *args, **kwargs):
+    def __init__(self, connect_method, *args, modem_id=None, **kwargs):
         """Init the SerialProtocol class."""
         super().__init__(*args, **kwargs)
         self._transport = None
@@ -80,9 +114,19 @@ class Protocol(asyncio.Protocol):
         self._connect_method = connect_method
         self._writer_task = None
         self._writer_lock = asyncio.Lock()
-        outbound_write_manager.protocol_write = self.write
+        self._modem_id = modem_id if modem_id is not None else "default"
+        outbound_write_manager.register_modem(self._modem_id, self.write)
+        if modem_id is None or modem_id == "default":
+            # Legacy single-modem contract: the default modem is also the
+            # fallback write target for unowned destinations.
+            outbound_write_manager.protocol_write = self.write
         register_outbound_handlers()
         register_command_handlers()
+
+    @property
+    def modem_id(self):
+        """Return the modem id used for outbound routing."""
+        return self._modem_id
 
     @property
     def connected(self) -> bool:
@@ -102,7 +146,7 @@ class Protocol(asyncio.Protocol):
     def connection_made(self, transport):
         """Run when a connection to the transport has been made."""
         self._transport = transport
-        publish_topic("connection.made")
+        publish_modem_topic(self._modem_id, "connection.made")
 
     def data_received(self, data):
         """Receive data from the serial transport."""
@@ -132,7 +176,7 @@ class Protocol(asyncio.Protocol):
                 last_msg_nak.extend(bytes([0x15]))
                 msg, _ = create(last_msg_nak)
             if msg:
-                asyncio.create_task(_publish_message(msg))
+                asyncio.create_task(_publish_message(msg, self._modem_id))
                 msg = None
 
             if not self._buffer or last_buffer == self._buffer:
@@ -161,7 +205,7 @@ class Protocol(asyncio.Protocol):
             _LOGGER.debug("Attempting to connect to modem")
             self._transport = await self._connect_method(protocol=self)
             if self._transport is None and not retry:
-                publish_topic("connection.failed")
+                publish_modem_topic(self._modem_id, "connection.failed")
                 raise ConnectionError("Modem did not respond to connection request")
             await asyncio.sleep(0.1)  # Let the transport finish connecting
             if not self.connected and retry:

--- a/pyinsteon/utils.py
+++ b/pyinsteon/utils.py
@@ -307,6 +307,16 @@ def calc_thermostat_mode(thermostat_mode_byte, sys_mode_map=None, sys_low=True):
     return sys_mode, fan_mode
 
 
+def modem_topic_prefix(modem_id):
+    """Return the pubsub topic prefix for a modem id.
+
+    Sanitized so any modem id (e.g. an HA config entry id) forms a valid
+    pubsub topic segment.
+    """
+    safe = "".join(ch if ch.isalnum() else "_" for ch in str(modem_id))
+    return f"modem_{safe}"
+
+
 def publish_topic(topic, logger=None, **kwargs):
     """Publish a topic and log errors."""
     # Send log message as caller not utils.

--- a/tests/test_multi_modem.py
+++ b/tests/test_multi_modem.py
@@ -1,0 +1,367 @@
+"""Multi-modem test harness (P2 acceptance criteria).
+
+Demonstrates the cross-modem outbound collision in the current architecture
+and encodes the acceptance contract for the address-routed write layer.
+
+Root cause: `outbound_write_manager` (pyinsteon/protocol/messages/outbound.py)
+is a module-level singleton. Every `Protocol.__init__` / connection overwrites
+`outbound_write_manager.protocol_write = self.write`, so with two connected
+modems ALL outbound traffic egresses the most recently connected modem,
+regardless of which Insteon network the destination device lives on.
+
+Tests:
+    test_outbound_collision_last_writer_wins
+        Documents today's broken behavior. PASSES on master. When the P2
+        router lands, this test MUST be updated/removed (it will fail).
+    test_acceptance_outbound_routes_by_address_ownership
+        The post-refactor contract. @expectedFailure until the P2
+        address-routed OutboundWriteManager exists.
+"""
+import asyncio
+import unittest
+from functools import partial
+
+from pyinsteon.address import Address
+from pyinsteon.protocol.messages.outbound import outbound_write_manager
+from pyinsteon.protocol.protocol import Protocol
+from pyinsteon.utils import publish_topic
+
+from tests import async_connect_mock, set_log_levels
+
+# Devices notionally on two different physical Insteon networks.
+DEVICE_ON_MODEM_A = Address("11.AA.AA")
+DEVICE_ON_MODEM_B = Address("22.BB.BB")
+
+SETTLE = 1.5  # async_connect sleeps 0.5s; writer loop needs headroom
+
+
+class _MockModem:
+    """A Protocol wired to a MockTransport with inspectable queues."""
+
+    def __init__(self, name):
+        self.name = name
+        self.read_queue = asyncio.Queue()
+        self.write_queue = asyncio.Queue()
+        self.protocol = Protocol(
+            connect_method=partial(
+                async_connect_mock,
+                self.read_queue,
+                self.write_queue,
+                random_nak=False,
+                auto_ack=True,
+            )
+        )
+
+    async def connect(self):
+        await self.protocol.async_connect(retry=False)
+
+    def close(self):
+        self.protocol.close()
+
+    def drain_writes(self):
+        """Return all raw byte payloads written to this modem's transport."""
+        out = []
+        while not self.write_queue.empty():
+            out.append(bytes(self.write_queue.get_nowait()))
+        return out
+
+
+def _writes_containing(writes, address: Address):
+    """Filter writes to those carrying the given destination address."""
+    needle = bytes(address)
+    return [w for w in writes if needle in w]
+
+
+class TestMultiModemOutbound(unittest.IsolatedAsyncioTestCase):
+    """Two-mock-modem outbound routing tests."""
+
+    async def asyncSetUp(self):
+        set_log_levels(logger_topics=True)
+        self.modem_a = _MockModem("A")
+        self.modem_b = _MockModem("B")
+        await self.modem_a.connect()
+        await self.modem_b.connect()  # B connects LAST -> owns the global write fn
+
+    async def asyncTearDown(self):
+        outbound_write_manager.unregister_modem("modem_a")
+        outbound_write_manager.unregister_modem("modem_b")
+        self.modem_a.close()
+        self.modem_b.close()
+        await asyncio.sleep(0.1)
+
+    async def test_outbound_collision_last_writer_wins(self):
+        """Legacy fallback preserved: with NO ownership assigned, traffic
+        follows the legacy protocol_write (last connected modem). This is
+        the pre-P2 behavior, intentionally kept for single-modem
+        back-compat when register_modem/assign_address are never called.
+        """
+        publish_topic(
+            "send.on", address=DEVICE_ON_MODEM_A, on_level=255, group=0
+        )
+        await asyncio.sleep(SETTLE)
+
+        writes_a = self.modem_a.drain_writes()
+        writes_b = self.modem_b.drain_writes()
+
+        # The wrong modem transmitted the command.
+        self.assertTrue(
+            _writes_containing(writes_b, DEVICE_ON_MODEM_A),
+            "Legacy fallback should route to last-connected modem when "
+            "no ownership is configured.",
+        )
+        # And the right modem stayed silent.
+        self.assertFalse(
+            _writes_containing(writes_a, DEVICE_ON_MODEM_A),
+            "Modem A unexpectedly transmitted; global write fn "
+            "no longer last-writer-wins.",
+        )
+
+    async def test_acceptance_outbound_routes_by_address_ownership(self):
+        """P2 acceptance contract: writes route by address ownership."""
+        outbound_write_manager.register_modem("modem_a", self.modem_a.protocol.write)
+        outbound_write_manager.register_modem("modem_b", self.modem_b.protocol.write)
+        outbound_write_manager.assign_address(DEVICE_ON_MODEM_A, "modem_a")
+        outbound_write_manager.assign_address(DEVICE_ON_MODEM_B, "modem_b")
+
+        publish_topic("send.on", address=DEVICE_ON_MODEM_A, on_level=255, group=0)
+        publish_topic("send.on", address=DEVICE_ON_MODEM_B, on_level=255, group=0)
+        await asyncio.sleep(SETTLE)
+
+        writes_a = self.modem_a.drain_writes()
+        writes_b = self.modem_b.drain_writes()
+
+        self.assertTrue(_writes_containing(writes_a, DEVICE_ON_MODEM_A))
+        self.assertTrue(_writes_containing(writes_b, DEVICE_ON_MODEM_B))
+        # Isolation: neither modem carries the other's traffic.
+        self.assertFalse(_writes_containing(writes_a, DEVICE_ON_MODEM_B))
+        self.assertFalse(_writes_containing(writes_b, DEVICE_ON_MODEM_A))
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestInsteonStackOwnership(unittest.IsolatedAsyncioTestCase):
+    """P1 acceptance: stacks sync router ownership automatically."""
+
+    async def asyncSetUp(self):
+        from pyinsteon.insteon_stack import InsteonStack
+
+        set_log_levels(logger_topics=True)
+        self.stacks = {}
+        self.queues = {}
+        for name in ("stack_a", "stack_b"):
+            stack = InsteonStack(name)
+            read_q, write_q = asyncio.Queue(), asyncio.Queue()
+            protocol = Protocol(
+                connect_method=partial(
+                    async_connect_mock,
+                    read_q,
+                    write_q,
+                    random_nak=False,
+                    auto_ack=True,
+                ),
+                modem_id=name,
+            )
+            await protocol.async_connect(retry=False)
+            self.stacks[name] = (stack, protocol)
+            self.queues[name] = write_q
+
+    async def asyncTearDown(self):
+        for name, (_stack, protocol) in self.stacks.items():
+            protocol.close()
+            outbound_write_manager.unregister_modem(name)
+        await asyncio.sleep(0.1)
+
+    def _drain(self, name):
+        out = []
+        while not self.queues[name].empty():
+            out.append(bytes(self.queues[name].get_nowait()))
+        return out
+
+    async def test_device_add_assigns_ownership_automatically(self):
+        """Adding a device to a stack's DeviceManager routes its traffic.
+
+        No manual assign_address calls: DEVICE_LIST_CHANGED subscription
+        inside InsteonStack must keep the router's ownership map in sync.
+        """
+        from pyinsteon.managers.device_id_manager import DeviceId
+
+        stack_a, _ = self.stacks["stack_a"]
+        stack_b, _ = self.stacks["stack_b"]
+        stack_a.devices[DEVICE_ON_MODEM_A] = DeviceId(
+            DEVICE_ON_MODEM_A, 0x02, 0x2A, 0x45
+        )
+        stack_b.devices[DEVICE_ON_MODEM_B] = DeviceId(
+            DEVICE_ON_MODEM_B, 0x02, 0x2A, 0x45
+        )
+
+        publish_topic("send.on", address=DEVICE_ON_MODEM_A, on_level=255, group=0)
+        publish_topic("send.on", address=DEVICE_ON_MODEM_B, on_level=255, group=0)
+        await asyncio.sleep(SETTLE)
+
+        writes_a = self._drain("stack_a")
+        writes_b = self._drain("stack_b")
+
+        self.assertTrue(_writes_containing(writes_a, DEVICE_ON_MODEM_A))
+        self.assertTrue(_writes_containing(writes_b, DEVICE_ON_MODEM_B))
+        self.assertFalse(_writes_containing(writes_a, DEVICE_ON_MODEM_B))
+        self.assertFalse(_writes_containing(writes_b, DEVICE_ON_MODEM_A))
+
+    async def test_device_removal_releases_ownership(self):
+        """Removing a device unassigns it from the router."""
+        from pyinsteon.managers.device_id_manager import DeviceId
+        from pyinsteon.address import Address as Addr
+
+        stack_a, _ = self.stacks["stack_a"]
+        addr = Addr("33.CC.CC")
+        stack_a.devices[addr] = DeviceId(addr, 0x02, 0x2A, 0x45)
+        stack_a.devices[addr] = None  # removal path
+        # Ownership released: router map must not reference stack_a
+        owner = outbound_write_manager._address_owner.get(str(addr))
+        self.assertIsNone(owner)
+
+
+class TestModemTopicNamespacing(unittest.IsolatedAsyncioTestCase):
+    """P3 acceptance: modem-scoped topics are attributable per modem."""
+
+    async def asyncSetUp(self):
+        set_log_levels(logger_topics=True)
+        self.events = {"stack_a": [], "stack_b": [], "legacy": []}
+        self.modems = {}
+        from pyinsteon.utils import subscribe_topic as sub
+
+        def _make_x10_cb(bucket):
+            def _x10_cb(raw_x10, x10_flag):
+                bucket.append("x10")
+            return _x10_cb
+
+        self._make_x10_cb = _make_x10_cb
+
+        def make_cb(bucket, label):
+            def _cb(**kwargs):
+                bucket.append(label)
+            return _cb
+
+        # Subscribe BEFORE connecting so connection.made is captured
+        self._cbs = []
+        for name in ("stack_a", "stack_b"):
+            cb = make_cb(self.events[name], "connection.made")
+            self._cbs.append(cb)  # strong refs; pypubsub holds weakly
+            sub(cb, f"modem_{name}.connection.made")
+            cbx = self._make_x10_cb(self.events[name])
+            self._cbs.append(cbx)
+            sub(cbx, f"modem_{name}.x10_received")
+        legacy_cb = self._make_x10_cb(self.events["legacy"])
+        self._cbs.append(legacy_cb)
+        sub(legacy_cb, "x10_received")
+
+        for name in ("stack_a", "stack_b"):
+            rq, wq = asyncio.Queue(), asyncio.Queue()
+            p = Protocol(
+                connect_method=partial(
+                    async_connect_mock, rq, wq, random_nak=False, auto_ack=True
+                ),
+                modem_id=name,
+            )
+            await p.async_connect(retry=False)
+            self.modems[name] = p
+
+    async def asyncTearDown(self):
+        for name, p in self.modems.items():
+            p.close()
+            outbound_write_manager.unregister_modem(name)
+        await asyncio.sleep(0.1)
+
+    async def test_connection_made_is_attributable(self):
+        """Each modem's connection.made fires only on its own namespace."""
+        await asyncio.sleep(0.2)
+        self.assertEqual(self.events["stack_a"].count("connection.made"), 1)
+        self.assertEqual(self.events["stack_b"].count("connection.made"), 1)
+
+    async def test_x10_inbound_attributed_to_receiving_modem(self):
+        """X10 frame into modem A fires A's namespace only, plus legacy."""
+        x10_frame = bytes([0x02, 0x52, 0x6E, 0x00])
+        self.modems["stack_a"].data_received(x10_frame)
+        await asyncio.sleep(0.5)
+
+        self.assertIn("x10", self.events["stack_a"])
+        self.assertNotIn("x10", self.events["stack_b"])
+        # Back-compat: legacy unprefixed topic still fires
+        self.assertIn("x10", self.events["legacy"])
+
+    async def test_reconnect_does_not_cross_modems(self):
+        """Modem A reconnecting must not signal modem B's namespace."""
+        a_before = self.events["stack_a"].count("connection.made")
+        b_before = self.events["stack_b"].count("connection.made")
+        # Simulate transport-level reconnect on A
+        self.modems["stack_a"].connection_made(self.modems["stack_a"].transport)
+        await asyncio.sleep(0.2)
+        self.assertEqual(
+            self.events["stack_a"].count("connection.made"), a_before + 1
+        )
+        self.assertEqual(self.events["stack_b"].count("connection.made"), b_before)
+
+
+class TestModemContextRouting(unittest.IsolatedAsyncioTestCase):
+    """Modem-scoped outbound commands route via MODEM_CONTEXT.
+
+    Modem-scoped messages (get_im_info, all-linking, X10 broadcasts)
+    carry no destination address. With two non-default modems, they
+    must route to the context-designated modem — this is what makes a
+    second hub's connect handshake possible at all.
+    """
+
+    async def asyncSetUp(self):
+        set_log_levels(logger_topics=True)
+        self.modems = {}
+        for name in ("ctx_a", "ctx_b"):
+            rq, wq = asyncio.Queue(), asyncio.Queue()
+            p = Protocol(
+                connect_method=partial(
+                    async_connect_mock, rq, wq, random_nak=False, auto_ack=True
+                ),
+                modem_id=name,
+            )
+            await p.async_connect(retry=False)
+            self.modems[name] = (p, wq)
+
+    async def asyncTearDown(self):
+        for name, (p, _wq) in self.modems.items():
+            p.close()
+            outbound_write_manager.unregister_modem(name)
+        await asyncio.sleep(0.1)
+
+    def _drain(self, name):
+        out = []
+        wq = self.modems[name][1]
+        while not wq.empty():
+            out.append(bytes(wq.get_nowait()))
+        return out
+
+    async def test_modem_scoped_command_routes_by_context(self):
+        """get_im_info under ctx_b's context egresses modem B only."""
+        from pyinsteon.protocol.messages.outbound import MODEM_CONTEXT
+
+        token = MODEM_CONTEXT.set("ctx_b")
+        try:
+            publish_topic("send.get_im_info")
+            await asyncio.sleep(SETTLE)
+        finally:
+            MODEM_CONTEXT.reset(token)
+
+        writes_a = self._drain("ctx_a")
+        writes_b = self._drain("ctx_b")
+        get_im_info = bytes([0x02, 0x60])
+        self.assertTrue(any(w.startswith(get_im_info) for w in writes_b))
+        self.assertFalse(any(w.startswith(get_im_info) for w in writes_a))
+
+    async def test_modem_scoped_command_without_context_is_dropped(self):
+        """No context + two modems: modem-scoped command dropped, not crossed."""
+        publish_topic("send.get_im_info")
+        await asyncio.sleep(SETTLE)
+        get_im_info = bytes([0x02, 0x60])
+        for name in ("ctx_a", "ctx_b"):
+            self.assertFalse(
+                any(w.startswith(get_im_info) for w in self._drain(name))
+            )


### PR DESCRIPTION
## Summary

Adds **multi-modem** support so more than one PLM/Hub can run in the same process, each with its own device manager, connection, and outbound write path.

This is used by a Home Assistant multi-hub custom component:

- https://github.com/patchg/insteon-multihub (release [v2026.7.6](https://github.com/patchg/insteon-multihub/releases/tag/v2026.7.6))
- Tagged multi-modem build: [multi-modem-2026.7.1](https://github.com/patchg/pyinsteon/releases/tag/multi-modem-2026.7.1)

### Design

- **`InsteonStack`**: one modem identity (`modem_id`), connection, `DeviceManager`, link manager, and per-stack device file (`insteon_devices_<id>.json`; default stack keeps `insteon_devices.json`).
- **Outbound routing**: `OutboundWriteManager` maps device addresses → modem, with `MODEM_CONTEXT` / `DEVICE_MANAGER_CONTEXT` for modem-scoped ops (all-link scenes, X10, modem ALDB, etc.).
- **Pub/sub**: modem-scoped topics for multi-modem consumers; unprefixed topics kept for single-modem compatibility.
- **Second-hub connect**: `async_get_configuration()` runs under `modem_context()` so multi-modem setups do not hang waiting for a dropped modem-scoped response.

### Single-modem compatibility

Module-level `async_connect` / `devices` remain the default stack path. Existing single-modem call sites should keep working without changes.

### Multi-modem usage (sketch)

```python
from pyinsteon import async_connect
from pyinsteon.insteon_stack import InsteonStack

await async_connect(host=..., username=..., password=...)  # default stack

barn = InsteonStack("barn")
await barn.async_connect(host=..., username=..., password=...)
await barn.async_load(workdir="/config")
```

## Test plan

- [ ] Single-modem: connect, load devices, on/off, ALDB load (regression)
- [ ] Two Hub 2s: both connect and stay up after cold start
- [ ] Device command routes to owning modem only
- [ ] All-link `scene_on` / `scene_off` under `stack.modem_context()` for non-default stack
- [ ] Unit tests in CI for this branch (if any new coverage is requested)

## Notes for maintainers

This is a sizable architectural addition. Happy to split follow-ups, add tests, or adjust API naming to match project conventions. HA integration work that depends on this lives outside this repo (custom component), so core pyinsteon can stay integration-agnostic.