### PR TITLE
Fix ALDB reads for i3 devices

### DIFF
--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -7,11 +7,10 @@ Insteon devices that either respond to or control the current device.
 import asyncio
 import logging
 
-from ..address import Address
 from ..constants import ALDBStatus, EngineVersion, ReadWriteMode
 from ..managers.aldb_read_manager import ALDBReadManager
-from .aldb_base import ALDBBase
-from .aldb_record import ALDBRecord
+from .aldb_base import HWM_RECORD, ALDBBase
+from .aldb_record import new_aldb_record_from_existing
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +28,7 @@ class ALDB(ALDBBase):
     ):
         """Init the ALDB class."""
         super().__init__(address=address, version=version, mem_addr=mem_addr)
+        self._top_mem_addr = mem_addr
         self._read_manager = ALDBReadManager(self._address, self._mem_addr)
 
     # pylint: disable=arguments-differ
@@ -40,6 +40,7 @@ class ALDB(ALDBBase):
         self._update_status(ALDBStatus.LOADING)
         # Drop phantom records above the first record address. Erased 0xFF
         # cells from i3 devices were saved there by prior versions.
+        self._mem_addr = min(self._mem_addr, self._top_mem_addr)
         for phantom_addr in [addr for addr in self._records if addr > self._mem_addr]:
             self._records.pop(phantom_addr)
         if refresh:
@@ -61,8 +62,9 @@ class ALDB(ALDBBase):
                 async for rec in self._read_manager.async_read(
                     mem_addr=0, num_recs=1, read_write_mode=mode
                 ):
-                    self._mem_addr = rec.mem_addr
-                    self._add_record(rec)
+                    if rec.mem_addr <= self._top_mem_addr:
+                        self._mem_addr = rec.mem_addr
+                        self._add_record(rec)
             finally:
                 await self._read_manager.async_stop()
 
@@ -81,15 +83,17 @@ class ALDB(ALDBBase):
         finally:
             await self._read_manager.async_stop()
 
-        hit_erased = self._read_manager.hit_erased
+        ended_in_erased_run = False
         if not self._is_loaded() and self._records:
             # Loading all records did not work so now we read individual missing
             # records. i3 devices erase deleted cells back to 0xFF rather than
             # clearing the in-use flag, so an erased cell mid-database is a
-            # deleted slot. Only a run of consecutive erased cells ends the walk.
+            # deleted slot. A single erased reply proves nothing, a garbled
+            # response looks the same. Only a run of consecutive erased
+            # cells ends the database; a silent cell just ends this attempt.
             consecutive_erased = 0
             next_record = self._calc_next_record()
-            while next_record and consecutive_erased < MAX_CONSECUTIVE_ERASED:
+            while next_record:
                 got_record = False
                 async for rec in self._read_manager.async_read(
                     mem_addr=next_record, num_recs=1
@@ -98,15 +102,17 @@ class ALDB(ALDBBase):
                 if got_record:
                     consecutive_erased = 0
                 elif self._read_manager.hit_erased:
-                    hit_erased = True
                     consecutive_erased += 1
                     self._add_record(self._deleted_record(next_record))
+                    if consecutive_erased >= MAX_CONSECUTIVE_ERASED:
+                        ended_in_erased_run = True
+                        break
                 else:
                     # The ALDB did not return the requested record so stop
                     break
                 next_record = self._calc_next_record()
 
-        if not self._is_loaded() and hit_erased:
+        if ended_in_erased_run and not self._is_loaded():
             self._close_erased_aldb()
 
         if (
@@ -125,16 +131,8 @@ class ALDB(ALDBBase):
 
     def _deleted_record(self, mem_addr):
         """Return a record representing an erased (deleted) i3 cell."""
-        return ALDBRecord(
-            memory=mem_addr,
-            controller=False,
-            group=0,
-            target=Address("000000"),
-            data1=0,
-            data2=0,
-            data3=0,
-            in_use=False,
-            high_water_mark=False,
+        return new_aldb_record_from_existing(
+            HWM_RECORD, mem_addr=mem_addr, high_water_mark=False
         )
 
     def _close_erased_aldb(self):
@@ -152,19 +150,7 @@ class ALDB(ALDBBase):
                 return
         hwm_addr = addrs[-1] - 8
         _LOGGER.debug("Synthesizing high water mark at 0x%04X", hwm_addr)
-        self._add_record(
-            ALDBRecord(
-                memory=hwm_addr,
-                controller=False,
-                group=0,
-                target=Address("000000"),
-                data1=0,
-                data2=0,
-                data3=0,
-                in_use=False,
-                high_water_mark=True,
-            )
-        )
+        self._add_record(new_aldb_record_from_existing(HWM_RECORD, mem_addr=hwm_addr))
 
     def _add_record(self, record) -> bool:
         """Add a record to the record set."""

--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -7,9 +7,11 @@ Insteon devices that either respond to or control the current device.
 import asyncio
 import logging
 
+from ..address import Address
 from ..constants import ALDBStatus, EngineVersion, ReadWriteMode
 from ..managers.aldb_read_manager import ALDBReadManager
 from .aldb_base import ALDBBase
+from .aldb_record import ALDBRecord
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +36,10 @@ class ALDB(ALDBBase):
         """Load the All-Link Database."""
         _LOGGER.debug("Loading the ALDB async")
         self._update_status(ALDBStatus.LOADING)
+        # Drop phantom records above the first record address. Erased 0xFF
+        # cells from i3 devices were saved there by prior versions.
+        for phantom_addr in [addr for addr in self._records if addr > self._mem_addr]:
+            self._records.pop(phantom_addr)
         if refresh:
             self.clear()
         else:
@@ -73,7 +79,7 @@ class ALDB(ALDBBase):
         finally:
             await self._read_manager.async_stop()
 
-        if not self._is_loaded() and num_recs != 0:
+        if not self._is_loaded() and self._records:
             # Loading all records did not work so now we read individual missing records
             next_record = self._calc_next_record()
             while next_record:
@@ -81,11 +87,16 @@ class ALDB(ALDBBase):
                     mem_addr=next_record, num_recs=1
                 ):
                     self._add_record(rec)
+                if self._read_manager.hit_erased:
+                    break
                 prev_record = next_record
                 next_record = self._calc_next_record()
                 if next_record == prev_record:
                     # The ALDB did not return the requested record so stop
                     break
+
+        if not self._is_loaded() and self._read_manager.hit_erased:
+            self._close_erased_aldb()
 
         if (
             not self._records
@@ -101,10 +112,42 @@ class ALDB(ALDBBase):
 
         return self._status
 
+    def _close_erased_aldb(self):
+        """Terminate a database that ends in erased 0xFF cells.
+
+        i3 devices have no 0x00 high water mark record; the database ends at
+        the first erased cell. Synthesize a high water mark there so the
+        database can reach loaded status.
+        """
+        addrs = sorted(self._records, reverse=True)
+        if not addrs or addrs[0] != self._mem_addr:
+            return
+        for first, second in zip(addrs, addrs[1:]):
+            if first - second != 8:
+                return
+        hwm_addr = addrs[-1] - 8
+        _LOGGER.debug("Synthesizing high water mark at 0x%04X", hwm_addr)
+        self._add_record(
+            ALDBRecord(
+                memory=hwm_addr,
+                controller=False,
+                group=0,
+                target=Address("000000"),
+                data1=0,
+                data2=0,
+                data3=0,
+                in_use=False,
+                high_water_mark=True,
+            )
+        )
+
     def _add_record(self, record) -> bool:
         """Add a record to the record set."""
         _LOGGER.debug("Loading record: %s", str(record))
         # Make sure the records make sense
+        if record.mem_addr > self._mem_addr:
+            _LOGGER.debug("Record is above the first record: %s", str(record))
+            return False
         if (
             self.high_water_mark_mem_addr
             and record.mem_addr < self.high_water_mark_mem_addr
@@ -137,12 +180,12 @@ class ALDB(ALDBBase):
         if last_addr == self._mem_addr:
             return last_addr - 8
 
-        for mem_addr in range(self._mem_addr, last_addr, -8):
+        for mem_addr in range(self._mem_addr, last_addr - 8, -8):
             try:
                 rec = self._records[mem_addr]
-                if mem_addr == last_addr and rec.is_high_water_mark:
+                if rec.is_high_water_mark:
                     return None
-            except IndexError:
+            except KeyError:
                 return mem_addr
 
         return last_addr - 8

--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -15,6 +15,8 @@ from .aldb_record import ALDBRecord
 
 _LOGGER = logging.getLogger(__name__)
 
+MAX_CONSECUTIVE_ERASED = 8
+
 
 class ALDB(ALDBBase):
     """All-Link Database for a device."""
@@ -79,23 +81,32 @@ class ALDB(ALDBBase):
         finally:
             await self._read_manager.async_stop()
 
+        hit_erased = self._read_manager.hit_erased
         if not self._is_loaded() and self._records:
-            # Loading all records did not work so now we read individual missing records
+            # Loading all records did not work so now we read individual missing
+            # records. i3 devices erase deleted cells back to 0xFF rather than
+            # clearing the in-use flag, so an erased cell mid-database is a
+            # deleted slot. Only a run of consecutive erased cells ends the walk.
+            consecutive_erased = 0
             next_record = self._calc_next_record()
-            while next_record:
+            while next_record and consecutive_erased < MAX_CONSECUTIVE_ERASED:
+                got_record = False
                 async for rec in self._read_manager.async_read(
                     mem_addr=next_record, num_recs=1
                 ):
-                    self._add_record(rec)
-                if self._read_manager.hit_erased:
-                    break
-                prev_record = next_record
-                next_record = self._calc_next_record()
-                if next_record == prev_record:
+                    got_record = self._add_record(rec) or got_record
+                if got_record:
+                    consecutive_erased = 0
+                elif self._read_manager.hit_erased:
+                    hit_erased = True
+                    consecutive_erased += 1
+                    self._add_record(self._deleted_record(next_record))
+                else:
                     # The ALDB did not return the requested record so stop
                     break
+                next_record = self._calc_next_record()
 
-        if not self._is_loaded() and self._read_manager.hit_erased:
+        if not self._is_loaded() and hit_erased:
             self._close_erased_aldb()
 
         if (
@@ -111,6 +122,20 @@ class ALDB(ALDBBase):
         self.set_load_status()
 
         return self._status
+
+    def _deleted_record(self, mem_addr):
+        """Return a record representing an erased (deleted) i3 cell."""
+        return ALDBRecord(
+            memory=mem_addr,
+            controller=False,
+            group=0,
+            target=Address("000000"),
+            data1=0,
+            data2=0,
+            data3=0,
+            in_use=False,
+            high_water_mark=False,
+        )
 
     def _close_erased_aldb(self):
         """Terminate a database that ends in erased 0xFF cells.

--- a/pyinsteon/managers/aldb_read_manager.py
+++ b/pyinsteon/managers/aldb_read_manager.py
@@ -26,6 +26,19 @@ def _is_multiple_records(mem_addr, num_recs):
     return (mem_addr == 0x00 and num_recs == 0) or num_recs > 1
 
 
+def is_erased_record(record: ALDBRecord) -> bool:
+    """Return True if the record is an erased (0xFF) ALDB cell.
+
+    i3 devices return erased cells as 0xFF bytes rather than the 0x00
+    high water mark older devices use. A 0xFF control flags byte decodes
+    as an in-use controller record that is not the high water mark, so it
+    must be detected explicitly. An in-use record can never target
+    FF.FF.FF, so that combination identifies an erased cell even if other
+    bytes are partially cleared.
+    """
+    return record.is_in_use and record.target == Address("FFFFFF")
+
+
 class ALDBReadManager:
     """ALDB Read Manager."""
 
@@ -35,6 +48,7 @@ class ALDBReadManager:
         self._first_record = first_record
         self._record_queue = asyncio.Queue()
         self._continue = True
+        self._hit_erased = False
 
         self._read_handler = ReadALDBCommandHandler(self._address)
         self._record_handler = ReceiveALDBRecordHandler(self._address)
@@ -46,6 +60,11 @@ class ALDBReadManager:
         subscribe_topic(
             self._aldb_status_changed, f"{self._address.id}.{ALDB_STATUS_CHANGED}"
         )
+
+    @property
+    def hit_erased(self) -> bool:
+        """Return True if the last read encountered an erased (0xFF) cell."""
+        return self._hit_erased
 
     async def async_read(
         self,
@@ -62,6 +81,7 @@ class ALDBReadManager:
         )
         self._clear_read_queue()
         self._continue = True
+        self._hit_erased = False
         if read_write_mode == ReadWriteMode.PEEK_POKE:
             read_all_method = self._read_all_peek
             read_one_method = self._read_one_peek
@@ -112,6 +132,12 @@ class ALDBReadManager:
             try:
                 async with async_timeout.timeout(TIMER_RECORD):
                     record = await self._record_queue.get()
+                    if record is not None and is_erased_record(record):
+                        self._hit_erased = True
+                        _LOGGER.debug(
+                            "_read_one got erased cell 0x%04X", record.mem_addr
+                        )
+                        return None
                     if (
                         record is not None
                         and record.mem_addr == mem_addr
@@ -226,6 +252,16 @@ class ALDBReadManager:
                         record: ALDBRecord = await self._record_queue.get()
                         if record is None:
                             _LOGGER.debug("_read_all completed")
+                            return
+                        if is_erased_record(record):
+                            # i3 devices stream erased 0xFF cells rather than
+                            # terminating at a 0x00 high water mark. Treat the
+                            # first erased cell as end of database.
+                            self._hit_erased = True
+                            _LOGGER.debug(
+                                "_read_all stopping at erased cell 0x%04X",
+                                record.mem_addr,
+                            )
                             return
                         _LOGGER.debug("_read_all returning record: %s", str(record))
                         if record.is_high_water_mark:

--- a/pyinsteon/managers/aldb_read_manager.py
+++ b/pyinsteon/managers/aldb_read_manager.py
@@ -132,7 +132,11 @@ class ALDBReadManager:
             try:
                 async with async_timeout.timeout(TIMER_RECORD):
                     record = await self._record_queue.get()
-                    if record is not None and is_erased_record(record):
+                    if (
+                        record is not None
+                        and is_erased_record(record)
+                        and mem_addr in (record.mem_addr, 0x0000)
+                    ):
                         self._hit_erased = True
                         _LOGGER.debug(
                             "_read_one got erased cell 0x%04X", record.mem_addr

--- a/tests/test_aldb/test_i3_erased.py
+++ b/tests/test_aldb/test_i3_erased.py
@@ -1,0 +1,134 @@
+"""Test handling of i3 erased (0xFF) ALDB cells."""
+
+# pylint: disable=protected-access
+import unittest
+
+from pyinsteon.address import Address
+from pyinsteon.aldb.aldb import ALDB
+from pyinsteon.aldb.aldb_record import ALDBRecord
+from pyinsteon.constants import ALDBStatus
+from pyinsteon.managers.aldb_read_manager import is_erased_record
+from tests.utils import async_case
+
+
+def _erased_record(mem_addr):
+    return ALDBRecord(
+        memory=mem_addr,
+        controller=True,
+        group=0xFF,
+        target=Address("FFFFFF"),
+        data1=0xFF,
+        data2=0xFF,
+        data3=0xFF,
+        in_use=True,
+        high_water_mark=False,
+        bit5=True,
+        bit4=True,
+    )
+
+
+def _real_record(mem_addr, group=1, controller=True):
+    return ALDBRecord(
+        memory=mem_addr,
+        controller=controller,
+        group=group,
+        target=Address("aabbcc"),
+        data1=3,
+        data2=28,
+        data3=1,
+        in_use=True,
+        high_water_mark=False,
+    )
+
+
+class TestErasedRecordDetection(unittest.TestCase):
+    """Test is_erased_record."""
+
+    def test_detects_erased_cell(self):
+        """An all 0xFF record is erased."""
+        assert is_erased_record(_erased_record(0xFFFC))
+
+    def test_real_record_not_erased(self):
+        """A real link record is not erased."""
+        assert not is_erased_record(_real_record(0x0FFF))
+
+    def test_hwm_not_erased(self):
+        """A 0x00 high water mark record is not erased."""
+        hwm = ALDBRecord(
+            memory=0x0FBF,
+            controller=False,
+            group=0,
+            target=Address("000000"),
+            data1=0,
+            data2=0,
+            data3=0,
+            in_use=False,
+            high_water_mark=True,
+        )
+        assert not is_erased_record(hwm)
+
+
+class TestErasedAldbHandling(unittest.TestCase):
+    """Test ALDB behavior around erased cells and phantoms."""
+
+    @async_case
+    async def test_add_record_rejects_phantom_above_first(self):
+        """Records above the first record address are rejected."""
+        aldb = ALDB(Address("112233"))
+        assert not aldb._add_record(_erased_record(0xFFFC))
+        assert 0xFFFC not in aldb
+
+    @async_case
+    async def test_calc_next_record_returns_missing(self):
+        """The first missing address in the chain is returned."""
+        aldb = ALDB(Address("112233"))
+        aldb._add_record(_real_record(0x0FFF))
+        aldb._add_record(_real_record(0x0FEF))
+        assert aldb._calc_next_record() == 0x0FF7
+
+    @async_case
+    async def test_calc_next_record_stops_at_hwm(self):
+        """No further reads once a high water mark exists."""
+        aldb = ALDB(Address("112233"))
+        aldb._add_record(_real_record(0x0FFF))
+        aldb._add_record(
+            ALDBRecord(
+                memory=0x0FF7,
+                controller=False,
+                group=0,
+                target=Address("000000"),
+                data1=0,
+                data2=0,
+                data3=0,
+                in_use=False,
+                high_water_mark=True,
+            )
+        )
+        assert aldb._calc_next_record() is None
+
+    @async_case
+    async def test_close_erased_aldb_synthesizes_hwm(self):
+        """A contiguous chain ending in erased cells becomes loaded."""
+        aldb = ALDB(Address("112233"))
+        aldb._add_record(_real_record(0x0FFF))
+        aldb._add_record(_real_record(0x0FF7, group=1, controller=False))
+        assert not aldb._is_loaded()
+        aldb._close_erased_aldb()
+        assert aldb.high_water_mark_mem_addr == 0x0FEF
+        assert aldb._is_loaded()
+        aldb.set_load_status()
+        assert aldb.status == ALDBStatus.LOADED
+
+    @async_case
+    async def test_close_erased_aldb_requires_contiguous_chain(self):
+        """A gap in the chain prevents synthesizing a high water mark."""
+        aldb = ALDB(Address("112233"))
+        aldb._add_record(_real_record(0x0FFF))
+        aldb._add_record(_real_record(0x0FEF))
+        aldb._close_erased_aldb()
+        assert aldb.high_water_mark_mem_addr is None
+        assert not aldb._is_loaded()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_aldb/test_i3_erased.py
+++ b/tests/test_aldb/test_i3_erased.py
@@ -4,10 +4,11 @@
 import unittest
 
 from pyinsteon.address import Address
-from pyinsteon.aldb.aldb import ALDB
+from pyinsteon.aldb.aldb import ALDB, MAX_CONSECUTIVE_ERASED
 from pyinsteon.aldb.aldb_record import ALDBRecord
 from pyinsteon.constants import ALDBStatus
 from pyinsteon.managers.aldb_read_manager import is_erased_record
+
 from tests.utils import async_case
 
 
@@ -128,6 +129,147 @@ class TestErasedAldbHandling(unittest.TestCase):
         aldb._close_erased_aldb()
         assert aldb.high_water_mark_mem_addr is None
         assert not aldb._is_loaded()
+
+
+def _hwm_record(mem_addr):
+    return ALDBRecord(
+        memory=mem_addr,
+        controller=False,
+        group=0,
+        target=Address("000000"),
+        data1=0,
+        data2=0,
+        data3=0,
+        in_use=False,
+        high_water_mark=True,
+    )
+
+
+ERASED = "erased"
+
+
+class ScriptedReadManager:
+    """Serve a scripted device memory map in place of the real read manager.
+
+    Each address maps to a record, ERASED for a cell that comes back as
+    0xFF bytes, or None for a cell the device never answers for.
+    """
+
+    def __init__(self, memory, top=0x0FFF):
+        """Init the ScriptedReadManager class."""
+        self.memory = memory
+        self.top = top
+        self.hit_erased = False
+        self.requests = []
+
+    async def async_read(self, mem_addr=0x00, num_recs=0, read_write_mode=None):
+        """Yield the scripted records for a read request."""
+        self.hit_erased = False
+        self.requests.append((mem_addr, num_recs))
+        if mem_addr == 0x00 and num_recs == 0:
+            for addr in sorted(self.memory, reverse=True):
+                cell = self.memory[addr]
+                if cell is None:
+                    return
+                if cell == ERASED:
+                    self.hit_erased = True
+                    return
+                yield cell
+                if cell.is_high_water_mark:
+                    return
+            return
+        addr = self.top if mem_addr == 0 else mem_addr
+        cell = self.memory.get(addr)
+        if cell == ERASED:
+            self.hit_erased = True
+        elif cell is not None:
+            yield cell
+
+    async def async_stop(self):
+        """Stop the read."""
+
+
+def _load_from(memory, aldb=None):
+    aldb = aldb or ALDB(Address("112233"))
+    aldb._read_manager = ScriptedReadManager(memory)
+    return aldb
+
+
+class TestLoadingAnErasedAldb(unittest.TestCase):
+    """Drive async_load through erased cells."""
+
+    @async_case
+    async def test_load_stays_partial_after_one_erased_cell_and_a_timeout(self):
+        """One erased read followed by silence is not the end of the database."""
+        memory = {addr: _real_record(addr) for addr in range(0x0FFF, 0x0FBF - 8, -8)}
+        memory[0x0FB7] = ERASED
+        memory[0x0FAF] = None
+        aldb = _load_from(memory)
+        status = await aldb.async_load()
+        assert status == ALDBStatus.PARTIAL
+        assert aldb.high_water_mark_mem_addr is None
+        assert 0x0FAF not in aldb
+
+    @async_case
+    async def test_load_completes_after_a_run_of_erased_cells(self):
+        """A long run of erased cells is the end of an i3 database."""
+        memory = {0x0FFF: _real_record(0x0FFF), 0x0FF7: _real_record(0x0FF7)}
+        for addr in range(0x0FEF, 0x0FEF - 8 * (MAX_CONSECUTIVE_ERASED + 2), -8):
+            memory[addr] = ERASED
+        aldb = _load_from(memory)
+        status = await aldb.async_load()
+        assert status == ALDBStatus.LOADED
+        assert aldb.high_water_mark_mem_addr is not None
+        assert aldb.high_water_mark_mem_addr < 0x0FF7
+
+    @async_case
+    async def test_load_reads_past_a_hole_to_the_real_high_water_mark(self):
+        """An erased cell mid-database is a deleted slot, not the end."""
+        memory = {
+            0x0FFF: _real_record(0x0FFF),
+            0x0FF7: ERASED,
+            0x0FEF: _real_record(0x0FEF, controller=False),
+            0x0FE7: _hwm_record(0x0FE7),
+        }
+        aldb = _load_from(memory)
+        status = await aldb.async_load()
+        assert status == ALDBStatus.LOADED
+        assert aldb.high_water_mark_mem_addr == 0x0FE7
+        assert not aldb[0x0FF7].is_in_use
+        assert aldb[0x0FEF].is_in_use
+
+    @async_case
+    async def test_saved_first_record_above_top_of_memory_is_reset(self):
+        """A database saved with phantom records heals on an ordinary load."""
+        saved = {addr: _erased_record(addr) for addr in range(0xFFFC, 0xFFBC, -8)}
+        saved[0x0FFF] = _real_record(0x0FFF)
+        aldb = ALDB(Address("112233"))
+        aldb.load_saved_records(ALDBStatus.PARTIAL, saved, 0xFFFC)
+        assert aldb.first_mem_addr == 0xFFFC
+        memory = {
+            0x0FFF: _real_record(0x0FFF),
+            0x0FF7: _real_record(0x0FF7, controller=False),
+            0x0FEF: _hwm_record(0x0FEF),
+        }
+        _load_from(memory, aldb)
+        status = await aldb.async_load()
+        assert aldb.first_mem_addr == 0x0FFF
+        assert status == ALDBStatus.LOADED
+        assert max(aldb) == 0x0FFF
+
+    @async_case
+    async def test_first_record_response_above_top_of_memory_is_ignored(self):
+        """A garbage first-record reply must not move the top of memory."""
+        memory = {
+            0xFFFC: _real_record(0xFFFC),
+            0x0FFF: _real_record(0x0FFF),
+            0x0FF7: _hwm_record(0x0FF7),
+        }
+        aldb = _load_from(memory)
+        aldb._read_manager.top = 0xFFFC
+        await aldb.async_load()
+        assert aldb.first_mem_addr == 0x0FFF
+        assert 0xFFFC not in aldb
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description:
i3 devices (i3 Paddle 0x01/0x57, Dial 0x01/0x58, Keypad 0x01/0x59, Outlet 0x02/0x3F) return erased ALDB cells as all-0xFF bytes instead of terminating with a 0x00 high water mark record. A 0xFF control flags byte decodes as an in-use controller record that is not the HWM, so today a read of an i3 device:

- accepts every erased cell as a real link (in use, controller, target FF.FF.FF, group 255), at bogus high memory addresses (0xFFFC descending)
- never sees a high water mark, so `_is_loaded()` can never be true and the ALDB is stuck at PARTIAL forever
- keeps requesting the next record indefinitely. I captured an i3 Keypad streaming erased cells from 0xFFFC down past 0xFC24, one record every couple of seconds, until the read was killed. On a live network this monopolizes the powerline for hours.

Because the ALDB never reaches LOADED, writes are also refused ("ALDB must be loaded before it can be written"), which breaks linking and scene management for these devices.

# Changes:

- `is_erased_record()` detects an erased cell (in-use bit set with target FF.FF.FF, a combination no valid record can have)
- `_read_all` stops at the first erased cell instead of chasing the erased region; `_read_one` treats an erased response as no record
- the individual-record recovery walk treats erased cells as deleted slots and keeps walking, since i3 erases deleted records back to 0xFF rather than clearing the in-use flag, so holes mid-database are legal. The walk ends after 8 consecutive erased cells
- a synthetic high water mark is recorded below the last record when the database ends in erased cells, so load status can reach LOADED
- `_calc_next_record` caught `IndexError` where the records dict raises `KeyError`, so gap detection never worked; also the recovery walk was gated on `num_recs != 0`, which no caller in the load path ever passes
- phantom records above the first record address are dropped at load time so databases saved by earlier versions self-heal

Verified on hardware with an i3 Keypad (KP014, v.58) that had never completed a load: previously ~46 phantom records and stuck PARTIAL, now 25 real records (including links the bulk read never surfaced) loaded in about two minutes, and subsequent writes work. Existing i1/i2 behavior is unchanged; a 0x00 HWM still terminates normally. Unit tests added for the erased-cell detection, the deleted-slot walk, and the gap calculation.