### PR TITLE
Back off maintenance traffic to devices that stop responding

### DIFF
--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -7,11 +7,10 @@ Insteon devices that either respond to or control the current device.
 import asyncio
 import logging
 
-from ..address import Address
 from ..constants import ALDBStatus, EngineVersion, ReadWriteMode
 from ..managers.aldb_read_manager import ALDBReadManager
-from .aldb_base import ALDBBase
-from .aldb_record import ALDBRecord
+from .aldb_base import HWM_RECORD, ALDBBase
+from .aldb_record import new_aldb_record_from_existing
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +28,7 @@ class ALDB(ALDBBase):
     ):
         """Init the ALDB class."""
         super().__init__(address=address, version=version, mem_addr=mem_addr)
+        self._top_mem_addr = mem_addr
         self._read_manager = ALDBReadManager(self._address, self._mem_addr)
 
     # pylint: disable=arguments-differ
@@ -40,6 +40,7 @@ class ALDB(ALDBBase):
         self._update_status(ALDBStatus.LOADING)
         # Drop phantom records above the first record address. Erased 0xFF
         # cells from i3 devices were saved there by prior versions.
+        self._mem_addr = min(self._mem_addr, self._top_mem_addr)
         for phantom_addr in [addr for addr in self._records if addr > self._mem_addr]:
             self._records.pop(phantom_addr)
         if refresh:
@@ -61,8 +62,9 @@ class ALDB(ALDBBase):
                 async for rec in self._read_manager.async_read(
                     mem_addr=0, num_recs=1, read_write_mode=mode
                 ):
-                    self._mem_addr = rec.mem_addr
-                    self._add_record(rec)
+                    if rec.mem_addr <= self._top_mem_addr:
+                        self._mem_addr = rec.mem_addr
+                        self._add_record(rec)
             finally:
                 await self._read_manager.async_stop()
 
@@ -81,15 +83,17 @@ class ALDB(ALDBBase):
         finally:
             await self._read_manager.async_stop()
 
-        hit_erased = self._read_manager.hit_erased
+        ended_in_erased_run = False
         if not self._is_loaded() and self._records:
             # Loading all records did not work so now we read individual missing
             # records. i3 devices erase deleted cells back to 0xFF rather than
             # clearing the in-use flag, so an erased cell mid-database is a
-            # deleted slot. Only a run of consecutive erased cells ends the walk.
+            # deleted slot. A single erased reply proves nothing, a garbled
+            # response looks the same. Only a run of consecutive erased
+            # cells ends the database; a silent cell just ends this attempt.
             consecutive_erased = 0
             next_record = self._calc_next_record()
-            while next_record and consecutive_erased < MAX_CONSECUTIVE_ERASED:
+            while next_record:
                 got_record = False
                 async for rec in self._read_manager.async_read(
                     mem_addr=next_record, num_recs=1
@@ -98,15 +102,17 @@ class ALDB(ALDBBase):
                 if got_record:
                     consecutive_erased = 0
                 elif self._read_manager.hit_erased:
-                    hit_erased = True
                     consecutive_erased += 1
                     self._add_record(self._deleted_record(next_record))
+                    if consecutive_erased >= MAX_CONSECUTIVE_ERASED:
+                        ended_in_erased_run = True
+                        break
                 else:
                     # The ALDB did not return the requested record so stop
                     break
                 next_record = self._calc_next_record()
 
-        if not self._is_loaded() and hit_erased:
+        if ended_in_erased_run and not self._is_loaded():
             self._close_erased_aldb()
 
         if (
@@ -125,16 +131,8 @@ class ALDB(ALDBBase):
 
     def _deleted_record(self, mem_addr):
         """Return a record representing an erased (deleted) i3 cell."""
-        return ALDBRecord(
-            memory=mem_addr,
-            controller=False,
-            group=0,
-            target=Address("000000"),
-            data1=0,
-            data2=0,
-            data3=0,
-            in_use=False,
-            high_water_mark=False,
+        return new_aldb_record_from_existing(
+            HWM_RECORD, mem_addr=mem_addr, high_water_mark=False
         )
 
     def _close_erased_aldb(self):
@@ -152,19 +150,7 @@ class ALDB(ALDBBase):
                 return
         hwm_addr = addrs[-1] - 8
         _LOGGER.debug("Synthesizing high water mark at 0x%04X", hwm_addr)
-        self._add_record(
-            ALDBRecord(
-                memory=hwm_addr,
-                controller=False,
-                group=0,
-                target=Address("000000"),
-                data1=0,
-                data2=0,
-                data3=0,
-                in_use=False,
-                high_water_mark=True,
-            )
-        )
+        self._add_record(new_aldb_record_from_existing(HWM_RECORD, mem_addr=hwm_addr))
 
     def _add_record(self, record) -> bool:
         """Add a record to the record set."""

--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -39,11 +39,12 @@ class ALDB(ALDBBase):
         self, mem_addr: int = 0x00, num_recs: int = 0x00, refresh: bool = False
     ):
         """Load the All-Link Database."""
-        if self._load_lock.locked():
-            # A load is already running; wait for it and share its result.
-            async with self._load_lock:
-                return self._status
+        waited = self._load_lock.locked()
         async with self._load_lock:
+            # A background load that lands behind a finished one is redundant.
+            # A refresh is not; the caller asked for a fresh read.
+            if waited and not refresh and self._status == ALDBStatus.LOADED:
+                return self._status
             return await self._async_load(
                 mem_addr=mem_addr, num_recs=num_recs, refresh=refresh
             )

--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -154,6 +154,8 @@ class ALDB(ALDBBase):
             )
 
         self.set_load_status()
+        if self._status == ALDBStatus.LOADED:
+            get_health(self._address).record_success()
 
         return self._status
 

--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -7,9 +7,11 @@ Insteon devices that either respond to or control the current device.
 import asyncio
 import logging
 
+from ..address import Address
 from ..constants import ALDBStatus, EngineVersion, ReadWriteMode
 from ..managers.aldb_read_manager import ALDBReadManager
 from .aldb_base import ALDBBase
+from .aldb_record import ALDBRecord
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +36,10 @@ class ALDB(ALDBBase):
         """Load the All-Link Database."""
         _LOGGER.debug("Loading the ALDB async")
         self._update_status(ALDBStatus.LOADING)
+        # Drop phantom records above the first record address. Erased 0xFF
+        # cells from i3 devices were saved there by prior versions.
+        for phantom_addr in [addr for addr in self._records if addr > self._mem_addr]:
+            self._records.pop(phantom_addr)
         if refresh:
             self.clear()
         else:
@@ -73,7 +79,7 @@ class ALDB(ALDBBase):
         finally:
             await self._read_manager.async_stop()
 
-        if not self._is_loaded() and num_recs != 0:
+        if not self._is_loaded() and self._records:
             # Loading all records did not work so now we read individual missing records
             next_record = self._calc_next_record()
             while next_record:
@@ -81,11 +87,16 @@ class ALDB(ALDBBase):
                     mem_addr=next_record, num_recs=1
                 ):
                     self._add_record(rec)
+                if self._read_manager.hit_erased:
+                    break
                 prev_record = next_record
                 next_record = self._calc_next_record()
                 if next_record == prev_record:
                     # The ALDB did not return the requested record so stop
                     break
+
+        if not self._is_loaded() and self._read_manager.hit_erased:
+            self._close_erased_aldb()
 
         if (
             not self._records
@@ -101,10 +112,42 @@ class ALDB(ALDBBase):
 
         return self._status
 
+    def _close_erased_aldb(self):
+        """Terminate a database that ends in erased 0xFF cells.
+
+        i3 devices have no 0x00 high water mark record; the database ends at
+        the first erased cell. Synthesize a high water mark there so the
+        database can reach loaded status.
+        """
+        addrs = sorted(self._records, reverse=True)
+        if not addrs or addrs[0] != self._mem_addr:
+            return
+        for first, second in zip(addrs, addrs[1:]):
+            if first - second != 8:
+                return
+        hwm_addr = addrs[-1] - 8
+        _LOGGER.debug("Synthesizing high water mark at 0x%04X", hwm_addr)
+        self._add_record(
+            ALDBRecord(
+                memory=hwm_addr,
+                controller=False,
+                group=0,
+                target=Address("000000"),
+                data1=0,
+                data2=0,
+                data3=0,
+                in_use=False,
+                high_water_mark=True,
+            )
+        )
+
     def _add_record(self, record) -> bool:
         """Add a record to the record set."""
         _LOGGER.debug("Loading record: %s", str(record))
         # Make sure the records make sense
+        if record.mem_addr > self._mem_addr:
+            _LOGGER.debug("Record is above the first record: %s", str(record))
+            return False
         if (
             self.high_water_mark_mem_addr
             and record.mem_addr < self.high_water_mark_mem_addr
@@ -137,12 +180,12 @@ class ALDB(ALDBBase):
         if last_addr == self._mem_addr:
             return last_addr - 8
 
-        for mem_addr in range(self._mem_addr, last_addr, -8):
+        for mem_addr in range(self._mem_addr, last_addr - 8, -8):
             try:
                 rec = self._records[mem_addr]
-                if mem_addr == last_addr and rec.is_high_water_mark:
+                if rec.is_high_water_mark:
                     return None
-            except IndexError:
+            except KeyError:
                 return mem_addr
 
         return last_addr - 8

--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -6,9 +6,11 @@ Insteon devices that either respond to or control the current device.
 
 import asyncio
 import logging
+import time
 
 from ..constants import ALDBStatus, EngineVersion, ReadWriteMode
 from ..managers.aldb_read_manager import ALDBReadManager
+from ..managers.device_health import get_health
 from .aldb_base import HWM_RECORD, ALDBBase
 from .aldb_record import new_aldb_record_from_existing
 
@@ -30,12 +32,34 @@ class ALDB(ALDBBase):
         super().__init__(address=address, version=version, mem_addr=mem_addr)
         self._top_mem_addr = mem_addr
         self._read_manager = ALDBReadManager(self._address, self._mem_addr)
+        self._load_lock = asyncio.Lock()
 
     # pylint: disable=arguments-differ
     async def async_load(
         self, mem_addr: int = 0x00, num_recs: int = 0x00, refresh: bool = False
     ):
         """Load the All-Link Database."""
+        if self._load_lock.locked():
+            # A load is already running; wait for it and share its result.
+            async with self._load_lock:
+                return self._status
+        async with self._load_lock:
+            return await self._async_load(
+                mem_addr=mem_addr, num_recs=num_recs, refresh=refresh
+            )
+
+    async def _async_load(
+        self, mem_addr: int = 0x00, num_recs: int = 0x00, refresh: bool = False
+    ):
+        """Load the All-Link Database without reentrancy protection."""
+        health = get_health(self._address)
+        if not refresh and not health.can_attempt_maintenance():
+            _LOGGER.info(
+                "Deferring ALDB load of %s: device unreachable, next attempt in %ds",
+                self._address,
+                max(0, int(health.next_maintenance - time.monotonic())),
+            )
+            return self._status
         _LOGGER.debug("Loading the ALDB async")
         self._update_status(ALDBStatus.LOADING)
         # Drop phantom records above the first record address. Erased 0xFF
@@ -121,7 +145,7 @@ class ALDB(ALDBBase):
             and self._version not in [EngineVersion.I2CS, EngineVersion.OTHER]
         ):
             self._read_write_mode = ReadWriteMode.PEEK_POKE
-            return await self.async_load(
+            return await self._async_load(
                 mem_addr=mem_addr, num_recs=num_recs, refresh=refresh
             )
 

--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -15,6 +15,8 @@ from .aldb_record import ALDBRecord
 
 _LOGGER = logging.getLogger(__name__)
 
+MAX_CONSECUTIVE_ERASED = 8
+
 
 class ALDB(ALDBBase):
     """All-Link Database for a device."""
@@ -79,23 +81,32 @@ class ALDB(ALDBBase):
         finally:
             await self._read_manager.async_stop()
 
+        hit_erased = self._read_manager.hit_erased
         if not self._is_loaded() and self._records:
-            # Loading all records did not work so now we read individual missing records
+            # Loading all records did not work so now we read individual missing
+            # records. i3 devices erase deleted cells back to 0xFF rather than
+            # clearing the in-use flag, so an erased cell mid-database is a
+            # deleted slot. Only a run of consecutive erased cells ends the walk.
+            consecutive_erased = 0
             next_record = self._calc_next_record()
-            while next_record:
+            while next_record and consecutive_erased < MAX_CONSECUTIVE_ERASED:
+                got_record = False
                 async for rec in self._read_manager.async_read(
                     mem_addr=next_record, num_recs=1
                 ):
-                    self._add_record(rec)
-                if self._read_manager.hit_erased:
-                    break
-                prev_record = next_record
-                next_record = self._calc_next_record()
-                if next_record == prev_record:
+                    got_record = self._add_record(rec) or got_record
+                if got_record:
+                    consecutive_erased = 0
+                elif self._read_manager.hit_erased:
+                    hit_erased = True
+                    consecutive_erased += 1
+                    self._add_record(self._deleted_record(next_record))
+                else:
                     # The ALDB did not return the requested record so stop
                     break
+                next_record = self._calc_next_record()
 
-        if not self._is_loaded() and self._read_manager.hit_erased:
+        if not self._is_loaded() and hit_erased:
             self._close_erased_aldb()
 
         if (
@@ -111,6 +122,20 @@ class ALDB(ALDBBase):
         self.set_load_status()
 
         return self._status
+
+    def _deleted_record(self, mem_addr):
+        """Return a record representing an erased (deleted) i3 cell."""
+        return ALDBRecord(
+            memory=mem_addr,
+            controller=False,
+            group=0,
+            target=Address("000000"),
+            data1=0,
+            data2=0,
+            data3=0,
+            in_use=False,
+            high_water_mark=False,
+        )
 
     def _close_erased_aldb(self):
         """Terminate a database that ends in erased 0xFF cells.

--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -142,8 +142,12 @@ class ALDB(ALDBBase):
         if (
             not self._records
             and self._read_write_mode == ReadWriteMode.STANDARD
-            and self._version not in [EngineVersion.I2CS, EngineVersion.OTHER]
+            and self._version == EngineVersion.I1
+            and health.can_attempt_maintenance()
         ):
+            # Peek reads are a last resort for confirmed i1 devices only. A
+            # device that is simply not answering must not be walked one
+            # byte at a time.
             self._read_write_mode = ReadWriteMode.PEEK_POKE
             return await self._async_load(
                 mem_addr=mem_addr, num_recs=num_recs, refresh=refresh

--- a/pyinsteon/device_types/device_base.py
+++ b/pyinsteon/device_types/device_base.py
@@ -13,9 +13,9 @@ from ..constants import DeviceCategory, EngineVersion, PropertyType, ResponseSta
 from ..default_link import DefaultLink
 from ..device_types.device_commands import STATUS_COMMAND
 from ..handlers.to_device.engine_version_request import EngineVersionRequest
-from ..managers.device_health import get_health
 from ..handlers.to_device.ping import PingCommand
 from ..handlers.to_device.product_data_request import ProductDataRequestCommand
+from ..managers.device_health import get_health
 from ..managers.get_set_ext_property_manager import GetSetExtendedPropertyManager
 from ..managers.get_set_op_flag_manager import GetSetOperatingFlagsManager
 from ..managers.link_manager.default_links import async_add_default_links

--- a/pyinsteon/device_types/device_base.py
+++ b/pyinsteon/device_types/device_base.py
@@ -13,6 +13,7 @@ from ..constants import DeviceCategory, EngineVersion, PropertyType, ResponseSta
 from ..default_link import DefaultLink
 from ..device_types.device_commands import STATUS_COMMAND
 from ..handlers.to_device.engine_version_request import EngineVersionRequest
+from ..managers.device_health import get_health
 from ..handlers.to_device.ping import PingCommand
 from ..handlers.to_device.product_data_request import ProductDataRequestCommand
 from ..managers.get_set_ext_property_manager import GetSetExtendedPropertyManager
@@ -208,6 +209,12 @@ class Device(ABC):
 
     async def async_read_op_flags(self, group=None):
         """Read the device operating flags."""
+        if not get_health(self._address).can_attempt_maintenance():
+            _LOGGER.debug(
+                "Deferring operating flags read of %s: device unreachable",
+                self._address,
+            )
+            return ResponseStatus.FAILURE
         return await self._op_flags_manager.async_read(group=group)
 
     async def async_write_op_flags(self):
@@ -216,6 +223,12 @@ class Device(ABC):
 
     async def async_read_ext_properties(self, group=None):
         """Get the device extended properties."""
+        if not get_health(self._address).can_attempt_maintenance():
+            _LOGGER.debug(
+                "Deferring extended properties read of %s: device unreachable",
+                self._address,
+            )
+            return ResponseStatus.FAILURE
         return await self._ext_property_manager.async_read(group=group)
 
     async def async_write_ext_properties(self):

--- a/pyinsteon/handlers/to_device/direct_command.py
+++ b/pyinsteon/handlers/to_device/direct_command.py
@@ -7,6 +7,7 @@ import async_timeout
 
 from .. import ack_handler, direct_ack_handler, direct_nak_handler, nak_handler
 from ...constants import MessageFlagType, ResponseStatus
+from ...managers.device_health import get_health
 from ..outbound_base import OutboundHandlerBase
 
 TIMEOUT = 6  # Wait time for device response
@@ -34,9 +35,12 @@ class DirectCommandHandlerBase(OutboundHandlerBase):
         if ack_response == ResponseStatus.SUCCESS:
             try:
                 async with async_timeout.timeout(TIMEOUT + 0.1):
-                    return await self._message_response.get()
+                    response = await self._message_response.get()
+                    # Any device response, ACK or NAK, is proof of life.
+                    get_health(self._address).record_success()
+                    return response
             except asyncio.TimeoutError:
-                pass
+                get_health(self._address).record_failure()
         return ResponseStatus.FAILURE
 
     @ack_handler

--- a/pyinsteon/handlers/to_device/direct_command.py
+++ b/pyinsteon/handlers/to_device/direct_command.py
@@ -36,8 +36,11 @@ class DirectCommandHandlerBase(OutboundHandlerBase):
             try:
                 async with async_timeout.timeout(TIMEOUT + 0.1):
                     response = await self._message_response.get()
-                    # Any device response, ACK or NAK, is proof of life.
-                    get_health(self._address).record_success()
+                    # A response proves the device is alive but says nothing
+                    # about whether the operation will complete. Devices can
+                    # ACK every request and still never deliver data, so only
+                    # completed operations reset the failure count.
+                    get_health(self._address).heard()
                     return response
             except asyncio.TimeoutError:
                 get_health(self._address).record_failure()

--- a/pyinsteon/managers/aldb_read_manager.py
+++ b/pyinsteon/managers/aldb_read_manager.py
@@ -26,6 +26,19 @@ def _is_multiple_records(mem_addr, num_recs):
     return (mem_addr == 0x00 and num_recs == 0) or num_recs > 1
 
 
+def is_erased_record(record: ALDBRecord) -> bool:
+    """Return True if the record is an erased (0xFF) ALDB cell.
+
+    i3 devices return erased cells as 0xFF bytes rather than the 0x00
+    high water mark older devices use. A 0xFF control flags byte decodes
+    as an in-use controller record that is not the high water mark, so it
+    must be detected explicitly. An in-use record can never target
+    FF.FF.FF, so that combination identifies an erased cell even if other
+    bytes are partially cleared.
+    """
+    return record.is_in_use and record.target == Address("FFFFFF")
+
+
 class ALDBReadManager:
     """ALDB Read Manager."""
 
@@ -35,6 +48,7 @@ class ALDBReadManager:
         self._first_record = first_record
         self._record_queue = asyncio.Queue()
         self._continue = True
+        self._hit_erased = False
 
         self._read_handler = ReadALDBCommandHandler(self._address)
         self._record_handler = ReceiveALDBRecordHandler(self._address)
@@ -46,6 +60,11 @@ class ALDBReadManager:
         subscribe_topic(
             self._aldb_status_changed, f"{self._address.id}.{ALDB_STATUS_CHANGED}"
         )
+
+    @property
+    def hit_erased(self) -> bool:
+        """Return True if the last read encountered an erased (0xFF) cell."""
+        return self._hit_erased
 
     async def async_read(
         self,
@@ -62,6 +81,7 @@ class ALDBReadManager:
         )
         self._clear_read_queue()
         self._continue = True
+        self._hit_erased = False
         if read_write_mode == ReadWriteMode.PEEK_POKE:
             read_all_method = self._read_all_peek
             read_one_method = self._read_one_peek
@@ -112,6 +132,12 @@ class ALDBReadManager:
             try:
                 async with async_timeout.timeout(TIMER_RECORD):
                     record = await self._record_queue.get()
+                    if record is not None and is_erased_record(record):
+                        self._hit_erased = True
+                        _LOGGER.debug(
+                            "_read_one got erased cell 0x%04X", record.mem_addr
+                        )
+                        return None
                     if (
                         record is not None
                         and record.mem_addr == mem_addr
@@ -226,6 +252,16 @@ class ALDBReadManager:
                         record: ALDBRecord = await self._record_queue.get()
                         if record is None:
                             _LOGGER.debug("_read_all completed")
+                            return
+                        if is_erased_record(record):
+                            # i3 devices stream erased 0xFF cells rather than
+                            # terminating at a 0x00 high water mark. Treat the
+                            # first erased cell as end of database.
+                            self._hit_erased = True
+                            _LOGGER.debug(
+                                "_read_all stopping at erased cell 0x%04X",
+                                record.mem_addr,
+                            )
                             return
                         _LOGGER.debug("_read_all returning record: %s", str(record))
                         if record.is_high_water_mark:

--- a/pyinsteon/managers/aldb_read_manager.py
+++ b/pyinsteon/managers/aldb_read_manager.py
@@ -132,7 +132,11 @@ class ALDBReadManager:
             try:
                 async with async_timeout.timeout(TIMER_RECORD):
                     record = await self._record_queue.get()
-                    if record is not None and is_erased_record(record):
+                    if (
+                        record is not None
+                        and is_erased_record(record)
+                        and mem_addr in (record.mem_addr, 0x0000)
+                    ):
                         self._hit_erased = True
                         _LOGGER.debug(
                             "_read_one got erased cell 0x%04X", record.mem_addr

--- a/pyinsteon/managers/aldb_read_manager.py
+++ b/pyinsteon/managers/aldb_read_manager.py
@@ -16,7 +16,7 @@ from ..topics import ALDB_STATUS_CHANGED
 from ..utils import subscribe_topic
 
 RETRIES_ALL_MAX = 5
-RETRIES_ONE_MAX = 20
+RETRIES_ONE_MAX = 5
 TIMER_RECORD = 10
 _LOGGER = logging.getLogger(__name__)
 

--- a/pyinsteon/managers/aldb_read_manager.py
+++ b/pyinsteon/managers/aldb_read_manager.py
@@ -160,6 +160,8 @@ class ALDBReadManager:
                 retries -= 1
             await asyncio.sleep(0.1)
         _LOGGER.debug("_read_one completed")
+        if self._continue and not self._hit_erased:
+            get_health(self._address).record_failure()
         return None
 
     async def _read_one_peek(self, mem_addr):
@@ -290,6 +292,7 @@ class ALDBReadManager:
                         await asyncio.sleep(0.05)
             except asyncio.TimeoutError:
                 retries -= 1
+                get_health(self._address).record_failure()
 
         _LOGGER.debug("_read_all completed")
 

--- a/pyinsteon/managers/aldb_read_manager.py
+++ b/pyinsteon/managers/aldb_read_manager.py
@@ -11,6 +11,7 @@ from ..constants import ALDBStatus, ReadWriteMode, ResponseStatus
 from ..data_types.all_link_record_flags import AllLinkRecordFlags
 from ..handlers.from_device.receive_aldb_record import ReceiveALDBRecordHandler
 from ..handlers.to_device.read_aldb import ReadALDBCommandHandler
+from ..managers.device_health import get_health
 from ..managers.peek_poke_manager import get_peek_poke_manager
 from ..topics import ALDB_STATUS_CHANGED
 from ..utils import subscribe_topic
@@ -114,6 +115,11 @@ class ALDBReadManager:
         """Read one record."""
         retries = RETRIES_ONE_MAX
         while retries and self._continue:
+            if not get_health(self._address).can_attempt_maintenance():
+                _LOGGER.debug(
+                    "Aborting ALDB read of %s: device unreachable", self._address
+                )
+                return None
             response = await self._read_handler.async_send(
                 mem_addr=mem_addr, num_recs=1
             )
@@ -195,9 +201,12 @@ class ALDBReadManager:
         """Peek one byte."""
         mem_addr = self._first_record if mem_addr == 0 else mem_addr
         _LOGGER.debug("Peeking memory address: 0x%04X", mem_addr)
-        retries_byte = 20
+        retries_byte = 5
         timeout = 3
         while retries_byte:
+            if not get_health(self._address).can_attempt_maintenance():
+                _LOGGER.debug("Aborting peek of %s: device unreachable", self._address)
+                return None
             while not self._peek_bytes_received.empty():
                 await self._peek_bytes_received.get()
             result = await self._peek_manager.async_peek(mem_addr)
@@ -235,6 +244,11 @@ class ALDBReadManager:
         retries = RETRIES_ALL_MAX
         mem_addr = 0
         while retries and self._continue:
+            if not get_health(self._address).can_attempt_maintenance():
+                _LOGGER.debug(
+                    "Aborting ALDB read of %s: device unreachable", self._address
+                )
+                return
             response = await self._read_handler.async_send(
                 mem_addr=mem_addr, num_recs=0
             )

--- a/pyinsteon/managers/aldb_read_manager.py
+++ b/pyinsteon/managers/aldb_read_manager.py
@@ -115,7 +115,7 @@ class ALDBReadManager:
         """Read one record."""
         retries = RETRIES_ONE_MAX
         while retries and self._continue:
-            if not get_health(self._address).can_attempt_maintenance():
+            if not get_health(self._address).can_continue_operation():
                 _LOGGER.debug(
                     "Aborting ALDB read of %s: device unreachable", self._address
                 )
@@ -206,7 +206,7 @@ class ALDBReadManager:
         retries_byte = 5
         timeout = 3
         while retries_byte:
-            if not get_health(self._address).can_attempt_maintenance():
+            if not get_health(self._address).can_continue_operation():
                 _LOGGER.debug("Aborting peek of %s: device unreachable", self._address)
                 return None
             while not self._peek_bytes_received.empty():
@@ -246,7 +246,7 @@ class ALDBReadManager:
         retries = RETRIES_ALL_MAX
         mem_addr = 0
         while retries and self._continue:
-            if not get_health(self._address).can_attempt_maintenance():
+            if not get_health(self._address).can_continue_operation():
                 _LOGGER.debug(
                     "Aborting ALDB read of %s: device unreachable", self._address
                 )

--- a/pyinsteon/managers/device_health.py
+++ b/pyinsteon/managers/device_health.py
@@ -52,7 +52,7 @@ class DeviceHealth:
         over = self.consecutive_failures - FAILURE_BURST
         if over >= 0:
             delay = min(BACKOFF_MAX, BACKOFF_BASE * 2**over)
-            delay *= 0.75 + random.random() * 0.5
+            delay *= 1 - random.random() * 0.25
             self._next_maintenance = time.monotonic() + delay
 
     def can_attempt_maintenance(self) -> bool:
@@ -64,9 +64,14 @@ class DeviceHealth:
 
         A long operation on a lossy but responsive device accumulates some
         failures legitimately; abort only when the device has failed far
-        beyond the backoff burst.
+        beyond the backoff burst. Once the backoff window has expired one
+        operation is let through regardless, otherwise nothing could ever
+        record the success that resets the count.
         """
-        return self.consecutive_failures < FAILURE_BURST * 4
+        return (
+            self.consecutive_failures < FAILURE_BURST * 4
+            or self.can_attempt_maintenance()
+        )
 
 
 _HEALTH = {}

--- a/pyinsteon/managers/device_health.py
+++ b/pyinsteon/managers/device_health.py
@@ -1,10 +1,10 @@
 """Track per-device reachability and gate maintenance traffic.
 
 Interactive commands always send. Maintenance traffic (ALDB loads, device
-ID requests, status polls) backs off after repeated failures so an
-unreachable device cannot monopolize the powerline. Any inbound frame from
-the device clears the backoff; only command outcomes change the failure
-count, so a device we can hear but not reach keeps its failure history.
+ID requests, status polls) backs off after repeated operation failures so
+a dead or data-silent device cannot monopolize the powerline. Transport
+ACKs only prove liveness; completed operations reset the failure count and
+exhausted operations increment it.
 """
 
 import random
@@ -32,9 +32,13 @@ class DeviceHealth:
         return self._next_maintenance
 
     def heard(self):
-        """Record an inbound frame from the device."""
+        """Record an inbound frame from the device.
+
+        Hearing a device proves it is alive but not that operations against
+        it complete; devices can ACK every request and never deliver data.
+        Backoff clears only on operation success or timer expiry.
+        """
         self.last_heard = time.time()
-        self._next_maintenance = 0.0
 
     def record_success(self):
         """Record a successful command round trip."""

--- a/pyinsteon/managers/device_health.py
+++ b/pyinsteon/managers/device_health.py
@@ -59,6 +59,15 @@ class DeviceHealth:
         """Return True if maintenance traffic may be sent now."""
         return time.monotonic() >= self._next_maintenance
 
+    def can_continue_operation(self) -> bool:
+        """Return True if an in-flight operation should keep going.
+
+        A long operation on a lossy but responsive device accumulates some
+        failures legitimately; abort only when the device has failed far
+        beyond the backoff burst.
+        """
+        return self.consecutive_failures < FAILURE_BURST * 4
+
 
 _HEALTH = {}
 

--- a/pyinsteon/managers/device_health.py
+++ b/pyinsteon/managers/device_health.py
@@ -1,0 +1,69 @@
+"""Track per-device reachability and gate maintenance traffic.
+
+Interactive commands always send. Maintenance traffic (ALDB loads, device
+ID requests, status polls) backs off after repeated failures so an
+unreachable device cannot monopolize the powerline. Any inbound frame from
+the device clears the backoff; only command outcomes change the failure
+count, so a device we can hear but not reach keeps its failure history.
+"""
+
+import random
+import time
+
+from ..address import Address
+
+FAILURE_BURST = 3
+BACKOFF_BASE = 60
+BACKOFF_MAX = 3600
+
+
+class DeviceHealth:
+    """Reachability state for one device."""
+
+    def __init__(self):
+        """Init the DeviceHealth class."""
+        self.last_heard = None
+        self.consecutive_failures = 0
+        self._next_maintenance = 0.0
+
+    @property
+    def next_maintenance(self) -> float:
+        """Return the monotonic time maintenance may next be attempted."""
+        return self._next_maintenance
+
+    def heard(self):
+        """Record an inbound frame from the device."""
+        self.last_heard = time.time()
+        self._next_maintenance = 0.0
+
+    def record_success(self):
+        """Record a successful command round trip."""
+        self.consecutive_failures = 0
+        self._next_maintenance = 0.0
+        self.last_heard = time.time()
+
+    def record_failure(self):
+        """Record a failed command and extend the backoff window."""
+        self.consecutive_failures += 1
+        over = self.consecutive_failures - FAILURE_BURST
+        if over >= 0:
+            delay = min(BACKOFF_MAX, BACKOFF_BASE * 2**over)
+            delay *= 0.75 + random.random() * 0.5
+            self._next_maintenance = time.monotonic() + delay
+
+    def can_attempt_maintenance(self) -> bool:
+        """Return True if maintenance traffic may be sent now."""
+        return time.monotonic() >= self._next_maintenance
+
+
+_HEALTH = {}
+
+
+def get_health(address) -> DeviceHealth:
+    """Return the DeviceHealth record for an address."""
+    addr = Address(address).id
+    health = _HEALTH.get(addr)
+    if health is None:
+        health = DeviceHealth()
+        _HEALTH[addr] = health
+    return health

--- a/pyinsteon/managers/device_id_manager.py
+++ b/pyinsteon/managers/device_id_manager.py
@@ -10,6 +10,7 @@ import async_timeout
 from .. import pub
 from ..address import Address
 from ..constants import DeviceAction, ResponseStatus
+from .device_health import get_health
 from ..handlers.all_link_completed import AllLinkCompletedHandler
 from ..handlers.from_device.assign_to_all_link_group import AssignToAllLinkGroupCommand
 from ..handlers.from_device.delete_from_all_link_group import (
@@ -144,6 +145,11 @@ class DeviceIdManager(SubscriberBase):
 
     async def async_id_device(self, address: Address, refresh: bool = False):
         """Call ID Request command for all unknown devices."""
+        if not get_health(address).can_attempt_maintenance():
+            _LOGGER.debug(
+                "Deferring device ID request for %s: device unreachable", address
+            )
+            return None
 
         received_queue = asyncio.Queue()
 

--- a/pyinsteon/managers/device_id_manager.py
+++ b/pyinsteon/managers/device_id_manager.py
@@ -275,6 +275,9 @@ class DeviceIdManager(SubscriberBase):
                 if device_id is not None and device_id.cat is not None:
                     return
                 await asyncio.sleep(retry_wait)
+                if not get_health(address).can_attempt_maintenance():
+                    retries -= 1
+                    continue
                 response = await cmd.async_send()
                 if response in [
                     ResponseStatus.DIRECT_NAK_ALDB,

--- a/pyinsteon/managers/device_id_manager.py
+++ b/pyinsteon/managers/device_id_manager.py
@@ -10,7 +10,6 @@ import async_timeout
 from .. import pub
 from ..address import Address
 from ..constants import DeviceAction, ResponseStatus
-from .device_health import get_health
 from ..handlers.all_link_completed import AllLinkCompletedHandler
 from ..handlers.from_device.assign_to_all_link_group import AssignToAllLinkGroupCommand
 from ..handlers.from_device.delete_from_all_link_group import (
@@ -20,6 +19,7 @@ from ..handlers.to_device.id_request import IdRequestCommand
 from ..handlers.to_device.ping import PingCommand
 from ..subscriber_base import SubscriberBase
 from ..utils import subscribe_topic, unsubscribe_topic
+from .device_health import get_health
 
 _LOGGER = logging.getLogger(__name__)
 MAX_RETRIES = 5

--- a/pyinsteon/managers/get_set_ext_property_manager.py
+++ b/pyinsteon/managers/get_set_ext_property_manager.py
@@ -9,6 +9,7 @@ from ..address import Address
 from ..config.extended_property import ExtendedProperty
 from ..constants import PropertyType, ResponseStatus
 from ..handlers.from_device.ext_get_response import ExtendedGetResponseHandler
+from .device_health import get_health
 from ..handlers.to_device.extended_get import ExtendedGetCommand
 from ..handlers.to_device.extended_set import ExtendedSetCommand
 from ..subscriber_base import SubscriberBase
@@ -17,7 +18,7 @@ from ..utils import multiple_status
 
 _LOGGER = logging.getLogger(__name__)
 TIMEOUT = 2
-RETRIES = 20
+RETRIES = 5
 
 PropertyInfo = namedtuple("PropertyInfo", "name group data_field bit set_cmd")
 
@@ -128,10 +129,21 @@ class GetSetExtendedPropertyManager(SubscriberBase):
     async def _async_read(self, group):
         retry = 0
         result = ResponseStatus.UNSENT
+        health = get_health(self._address)
         while retry < RETRIES and result != ResponseStatus.SUCCESS:
+            if not health.can_attempt_maintenance():
+                _LOGGER.debug(
+                    "Aborting extended property read of %s: device unreachable",
+                    self._address,
+                )
+                return ResponseStatus.FAILURE
             await self._get_command.async_send(group=group)
             result = await self._wait_for_get()
             retry += 1
+        if result == ResponseStatus.SUCCESS:
+            health.record_success()
+        else:
+            health.record_failure()
         return result
 
     async def _wait_for_get(self):

--- a/pyinsteon/managers/get_set_ext_property_manager.py
+++ b/pyinsteon/managers/get_set_ext_property_manager.py
@@ -9,12 +9,12 @@ from ..address import Address
 from ..config.extended_property import ExtendedProperty
 from ..constants import PropertyType, ResponseStatus
 from ..handlers.from_device.ext_get_response import ExtendedGetResponseHandler
-from .device_health import get_health
 from ..handlers.to_device.extended_get import ExtendedGetCommand
 from ..handlers.to_device.extended_set import ExtendedSetCommand
 from ..subscriber_base import SubscriberBase
 from ..topics import EXTENDED_PROPERTIES_CHANGED
 from ..utils import multiple_status
+from .device_health import get_health
 
 _LOGGER = logging.getLogger(__name__)
 TIMEOUT = 2

--- a/pyinsteon/managers/get_set_ext_property_manager.py
+++ b/pyinsteon/managers/get_set_ext_property_manager.py
@@ -131,7 +131,7 @@ class GetSetExtendedPropertyManager(SubscriberBase):
         result = ResponseStatus.UNSENT
         health = get_health(self._address)
         while retry < RETRIES and result != ResponseStatus.SUCCESS:
-            if not health.can_attempt_maintenance():
+            if not health.can_continue_operation():
                 _LOGGER.debug(
                     "Aborting extended property read of %s: device unreachable",
                     self._address,

--- a/pyinsteon/managers/status_manager.py
+++ b/pyinsteon/managers/status_manager.py
@@ -23,9 +23,9 @@ from typing import Callable, Dict, Union
 
 from ..address import Address
 from ..constants import ResponseStatus
-from .device_health import get_health
 from ..handlers.to_device.status_request import StatusRequestCommand
 from ..utils import multiple_status
+from .device_health import get_health
 
 _LOGGER = getLogger(__name__)
 _LOGGER.setLevel(DEBUG)

--- a/pyinsteon/managers/status_manager.py
+++ b/pyinsteon/managers/status_manager.py
@@ -23,6 +23,7 @@ from typing import Callable, Dict, Union
 
 from ..address import Address
 from ..constants import ResponseStatus
+from .device_health import get_health
 from ..handlers.to_device.status_request import StatusRequestCommand
 from ..utils import multiple_status
 
@@ -62,6 +63,12 @@ class StatusManager:
         self, status_type: Union[int, None] = None
     ) -> ResponseStatus:
         """Send the status request."""
+        if not get_health(self._address).can_attempt_maintenance():
+            _LOGGER.debug(
+                "Deferring status request for %s: device unreachable", self._address
+            )
+            return ResponseStatus.FAILURE
+
         if self._call_waiting:
             # No need for this call because an existing call is already scheduled
             _LOGGER.debug("No need to run this status request.")

--- a/pyinsteon/protocol/protocol.py
+++ b/pyinsteon/protocol/protocol.py
@@ -7,7 +7,8 @@ from queue import SimpleQueue
 from typing import Union
 
 from ..address import Address
-from ..constants import AckNak
+from ..constants import AckNak, MessageId
+from ..managers.device_health import get_health
 from ..utils import log_error, publish_topic
 from .command_to_msg import register_command_handlers
 from .messages.inbound import create
@@ -45,6 +46,8 @@ async def _publish_message(msg):
         for addr in _get_addresses_in_msg(msg):
             logger = logging.getLogger(f"pyinsteon.{Address(addr).id}")
             logger.debug("RX: %s", repr(msg))
+    if msg.message_id in (MessageId.STANDARD_RECEIVED, MessageId.EXTENDED_RECEIVED):
+        get_health(msg.address).heard()
     topic = None
     kwargs = {}
     try:

--- a/tests/test_aldb/test_aldb_load.py
+++ b/tests/test_aldb/test_aldb_load.py
@@ -1,0 +1,82 @@
+"""Test how concurrent ALDB loads share or repeat the read."""
+
+# pylint: disable=protected-access
+import asyncio
+import unittest
+
+from pyinsteon.address import Address
+from pyinsteon.aldb.aldb import ALDB
+from pyinsteon.aldb.aldb_record import ALDBRecord
+from pyinsteon.constants import ALDBStatus
+
+from tests.utils import async_case
+
+
+def _record(mem_addr, high_water_mark=False):
+    return ALDBRecord(
+        memory=mem_addr,
+        controller=not high_water_mark,
+        group=0 if high_water_mark else 1,
+        target=Address("000000" if high_water_mark else "aabbcc"),
+        data1=0,
+        data2=0,
+        data3=0,
+        in_use=not high_water_mark,
+        high_water_mark=high_water_mark,
+    )
+
+
+class GatedReadManager:
+    """Serve a two record database, holding each bulk read until released."""
+
+    def __init__(self):
+        """Init the GatedReadManager class."""
+        self.release = asyncio.Event()
+        self.bulk_reads = 0
+        self.hit_erased = False
+
+    async def async_read(self, mem_addr=0x00, num_recs=0, read_write_mode=None):
+        """Yield the records once released."""
+        if mem_addr == 0x00 and num_recs == 0:
+            self.bulk_reads += 1
+            await self.release.wait()
+            yield _record(0x0FFF)
+            yield _record(0x0FF7, high_water_mark=True)
+        elif mem_addr in (0x00, 0x0FFF):
+            yield _record(0x0FFF)
+
+    async def async_stop(self):
+        """Stop the read."""
+
+
+class TestConcurrentLoads(unittest.TestCase):
+    """Test overlapping calls to async_load."""
+
+    async def _run_overlapping(self, second_refresh):
+        aldb = ALDB(Address("112233"))
+        aldb._read_manager = GatedReadManager()
+        first = asyncio.create_task(aldb.async_load())
+        await asyncio.sleep(0.05)
+        second = asyncio.create_task(aldb.async_load(refresh=second_refresh))
+        await asyncio.sleep(0.05)
+        aldb._read_manager.release.set()
+        statuses = await asyncio.gather(first, second)
+        return aldb, statuses
+
+    @async_case
+    async def test_background_load_shares_the_read_in_flight(self):
+        """A second plain load waits for the first and reuses its result."""
+        aldb, statuses = await self._run_overlapping(second_refresh=False)
+        assert statuses == [ALDBStatus.LOADED, ALDBStatus.LOADED]
+        assert aldb._read_manager.bulk_reads == 1
+
+    @async_case
+    async def test_refresh_is_not_swallowed_by_a_load_in_flight(self):
+        """A refresh asked for during a load still reads the device."""
+        aldb, statuses = await self._run_overlapping(second_refresh=True)
+        assert statuses == [ALDBStatus.LOADED, ALDBStatus.LOADED]
+        assert aldb._read_manager.bulk_reads == 2
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_aldb/test_i3_erased.py
+++ b/tests/test_aldb/test_i3_erased.py
@@ -1,0 +1,134 @@
+"""Test handling of i3 erased (0xFF) ALDB cells."""
+
+# pylint: disable=protected-access
+import unittest
+
+from pyinsteon.address import Address
+from pyinsteon.aldb.aldb import ALDB
+from pyinsteon.aldb.aldb_record import ALDBRecord
+from pyinsteon.constants import ALDBStatus
+from pyinsteon.managers.aldb_read_manager import is_erased_record
+from tests.utils import async_case
+
+
+def _erased_record(mem_addr):
+    return ALDBRecord(
+        memory=mem_addr,
+        controller=True,
+        group=0xFF,
+        target=Address("FFFFFF"),
+        data1=0xFF,
+        data2=0xFF,
+        data3=0xFF,
+        in_use=True,
+        high_water_mark=False,
+        bit5=True,
+        bit4=True,
+    )
+
+
+def _real_record(mem_addr, group=1, controller=True):
+    return ALDBRecord(
+        memory=mem_addr,
+        controller=controller,
+        group=group,
+        target=Address("aabbcc"),
+        data1=3,
+        data2=28,
+        data3=1,
+        in_use=True,
+        high_water_mark=False,
+    )
+
+
+class TestErasedRecordDetection(unittest.TestCase):
+    """Test is_erased_record."""
+
+    def test_detects_erased_cell(self):
+        """An all 0xFF record is erased."""
+        assert is_erased_record(_erased_record(0xFFFC))
+
+    def test_real_record_not_erased(self):
+        """A real link record is not erased."""
+        assert not is_erased_record(_real_record(0x0FFF))
+
+    def test_hwm_not_erased(self):
+        """A 0x00 high water mark record is not erased."""
+        hwm = ALDBRecord(
+            memory=0x0FBF,
+            controller=False,
+            group=0,
+            target=Address("000000"),
+            data1=0,
+            data2=0,
+            data3=0,
+            in_use=False,
+            high_water_mark=True,
+        )
+        assert not is_erased_record(hwm)
+
+
+class TestErasedAldbHandling(unittest.TestCase):
+    """Test ALDB behavior around erased cells and phantoms."""
+
+    @async_case
+    async def test_add_record_rejects_phantom_above_first(self):
+        """Records above the first record address are rejected."""
+        aldb = ALDB(Address("112233"))
+        assert not aldb._add_record(_erased_record(0xFFFC))
+        assert 0xFFFC not in aldb
+
+    @async_case
+    async def test_calc_next_record_returns_missing(self):
+        """The first missing address in the chain is returned."""
+        aldb = ALDB(Address("112233"))
+        aldb._add_record(_real_record(0x0FFF))
+        aldb._add_record(_real_record(0x0FEF))
+        assert aldb._calc_next_record() == 0x0FF7
+
+    @async_case
+    async def test_calc_next_record_stops_at_hwm(self):
+        """No further reads once a high water mark exists."""
+        aldb = ALDB(Address("112233"))
+        aldb._add_record(_real_record(0x0FFF))
+        aldb._add_record(
+            ALDBRecord(
+                memory=0x0FF7,
+                controller=False,
+                group=0,
+                target=Address("000000"),
+                data1=0,
+                data2=0,
+                data3=0,
+                in_use=False,
+                high_water_mark=True,
+            )
+        )
+        assert aldb._calc_next_record() is None
+
+    @async_case
+    async def test_close_erased_aldb_synthesizes_hwm(self):
+        """A contiguous chain ending in erased cells becomes loaded."""
+        aldb = ALDB(Address("112233"))
+        aldb._add_record(_real_record(0x0FFF))
+        aldb._add_record(_real_record(0x0FF7, group=1, controller=False))
+        assert not aldb._is_loaded()
+        aldb._close_erased_aldb()
+        assert aldb.high_water_mark_mem_addr == 0x0FEF
+        assert aldb._is_loaded()
+        aldb.set_load_status()
+        assert aldb.status == ALDBStatus.LOADED
+
+    @async_case
+    async def test_close_erased_aldb_requires_contiguous_chain(self):
+        """A gap in the chain prevents synthesizing a high water mark."""
+        aldb = ALDB(Address("112233"))
+        aldb._add_record(_real_record(0x0FFF))
+        aldb._add_record(_real_record(0x0FEF))
+        aldb._close_erased_aldb()
+        assert aldb.high_water_mark_mem_addr is None
+        assert not aldb._is_loaded()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_aldb/test_i3_erased.py
+++ b/tests/test_aldb/test_i3_erased.py
@@ -4,10 +4,11 @@
 import unittest
 
 from pyinsteon.address import Address
-from pyinsteon.aldb.aldb import ALDB
+from pyinsteon.aldb.aldb import ALDB, MAX_CONSECUTIVE_ERASED
 from pyinsteon.aldb.aldb_record import ALDBRecord
 from pyinsteon.constants import ALDBStatus
 from pyinsteon.managers.aldb_read_manager import is_erased_record
+
 from tests.utils import async_case
 
 
@@ -128,6 +129,147 @@ class TestErasedAldbHandling(unittest.TestCase):
         aldb._close_erased_aldb()
         assert aldb.high_water_mark_mem_addr is None
         assert not aldb._is_loaded()
+
+
+def _hwm_record(mem_addr):
+    return ALDBRecord(
+        memory=mem_addr,
+        controller=False,
+        group=0,
+        target=Address("000000"),
+        data1=0,
+        data2=0,
+        data3=0,
+        in_use=False,
+        high_water_mark=True,
+    )
+
+
+ERASED = "erased"
+
+
+class ScriptedReadManager:
+    """Serve a scripted device memory map in place of the real read manager.
+
+    Each address maps to a record, ERASED for a cell that comes back as
+    0xFF bytes, or None for a cell the device never answers for.
+    """
+
+    def __init__(self, memory, top=0x0FFF):
+        """Init the ScriptedReadManager class."""
+        self.memory = memory
+        self.top = top
+        self.hit_erased = False
+        self.requests = []
+
+    async def async_read(self, mem_addr=0x00, num_recs=0, read_write_mode=None):
+        """Yield the scripted records for a read request."""
+        self.hit_erased = False
+        self.requests.append((mem_addr, num_recs))
+        if mem_addr == 0x00 and num_recs == 0:
+            for addr in sorted(self.memory, reverse=True):
+                cell = self.memory[addr]
+                if cell is None:
+                    return
+                if cell == ERASED:
+                    self.hit_erased = True
+                    return
+                yield cell
+                if cell.is_high_water_mark:
+                    return
+            return
+        addr = self.top if mem_addr == 0 else mem_addr
+        cell = self.memory.get(addr)
+        if cell == ERASED:
+            self.hit_erased = True
+        elif cell is not None:
+            yield cell
+
+    async def async_stop(self):
+        """Stop the read."""
+
+
+def _load_from(memory, aldb=None):
+    aldb = aldb or ALDB(Address("112233"))
+    aldb._read_manager = ScriptedReadManager(memory)
+    return aldb
+
+
+class TestLoadingAnErasedAldb(unittest.TestCase):
+    """Drive async_load through erased cells."""
+
+    @async_case
+    async def test_load_stays_partial_after_one_erased_cell_and_a_timeout(self):
+        """One erased read followed by silence is not the end of the database."""
+        memory = {addr: _real_record(addr) for addr in range(0x0FFF, 0x0FBF - 8, -8)}
+        memory[0x0FB7] = ERASED
+        memory[0x0FAF] = None
+        aldb = _load_from(memory)
+        status = await aldb.async_load()
+        assert status == ALDBStatus.PARTIAL
+        assert aldb.high_water_mark_mem_addr is None
+        assert 0x0FAF not in aldb
+
+    @async_case
+    async def test_load_completes_after_a_run_of_erased_cells(self):
+        """A long run of erased cells is the end of an i3 database."""
+        memory = {0x0FFF: _real_record(0x0FFF), 0x0FF7: _real_record(0x0FF7)}
+        for addr in range(0x0FEF, 0x0FEF - 8 * (MAX_CONSECUTIVE_ERASED + 2), -8):
+            memory[addr] = ERASED
+        aldb = _load_from(memory)
+        status = await aldb.async_load()
+        assert status == ALDBStatus.LOADED
+        assert aldb.high_water_mark_mem_addr is not None
+        assert aldb.high_water_mark_mem_addr < 0x0FF7
+
+    @async_case
+    async def test_load_reads_past_a_hole_to_the_real_high_water_mark(self):
+        """An erased cell mid-database is a deleted slot, not the end."""
+        memory = {
+            0x0FFF: _real_record(0x0FFF),
+            0x0FF7: ERASED,
+            0x0FEF: _real_record(0x0FEF, controller=False),
+            0x0FE7: _hwm_record(0x0FE7),
+        }
+        aldb = _load_from(memory)
+        status = await aldb.async_load()
+        assert status == ALDBStatus.LOADED
+        assert aldb.high_water_mark_mem_addr == 0x0FE7
+        assert not aldb[0x0FF7].is_in_use
+        assert aldb[0x0FEF].is_in_use
+
+    @async_case
+    async def test_saved_first_record_above_top_of_memory_is_reset(self):
+        """A database saved with phantom records heals on an ordinary load."""
+        saved = {addr: _erased_record(addr) for addr in range(0xFFFC, 0xFFBC, -8)}
+        saved[0x0FFF] = _real_record(0x0FFF)
+        aldb = ALDB(Address("112233"))
+        aldb.load_saved_records(ALDBStatus.PARTIAL, saved, 0xFFFC)
+        assert aldb.first_mem_addr == 0xFFFC
+        memory = {
+            0x0FFF: _real_record(0x0FFF),
+            0x0FF7: _real_record(0x0FF7, controller=False),
+            0x0FEF: _hwm_record(0x0FEF),
+        }
+        _load_from(memory, aldb)
+        status = await aldb.async_load()
+        assert aldb.first_mem_addr == 0x0FFF
+        assert status == ALDBStatus.LOADED
+        assert max(aldb) == 0x0FFF
+
+    @async_case
+    async def test_first_record_response_above_top_of_memory_is_ignored(self):
+        """A garbage first-record reply must not move the top of memory."""
+        memory = {
+            0xFFFC: _real_record(0xFFFC),
+            0x0FFF: _real_record(0x0FFF),
+            0x0FF7: _hwm_record(0x0FF7),
+        }
+        aldb = _load_from(memory)
+        aldb._read_manager.top = 0xFFFC
+        await aldb.async_load()
+        assert aldb.first_mem_addr == 0x0FFF
+        assert 0xFFFC not in aldb
 
 
 if __name__ == "__main__":

--- a/tests/test_managers/test_device_health.py
+++ b/tests/test_managers/test_device_health.py
@@ -87,6 +87,38 @@ class TestDeviceHealth(unittest.TestCase):
         h2 = get_health("AABBCC")
         assert h1 is h2
 
+    def test_backoff_never_exceeds_the_cap(self):
+        """Jitter is applied inside the cap, never on top of it."""
+        health = DeviceHealth()
+        with patch("pyinsteon.managers.device_health.time") as mock_time, patch(
+            "pyinsteon.managers.device_health.random"
+        ) as mock_random:
+            mock_time.monotonic.return_value = 1000.0
+            mock_time.time.return_value = 1000.0
+            mock_random.random.return_value = 1.0
+            for _ in range(FAILURE_BURST + 20):
+                health.record_failure()
+            assert health.next_maintenance - 1000.0 <= BACKOFF_MAX
+
+    def test_expired_backoff_lets_one_more_operation_through(self):
+        """A device far past the failure bar still gets a probe each window.
+
+        Without this a device that hit the bar could never record a success
+        because every operation aborts before it sends anything.
+        """
+        health = DeviceHealth()
+        with patch("pyinsteon.managers.device_health.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            mock_time.time.return_value = 1000.0
+            for _ in range(FAILURE_BURST * 4 + 3):
+                health.record_failure()
+            assert not health.can_continue_operation()
+            mock_time.monotonic.return_value = 1000.0 + BACKOFF_MAX * 2
+            assert health.can_attempt_maintenance()
+            assert health.can_continue_operation()
+            health.record_failure()
+            assert not health.can_continue_operation()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_managers/test_device_health.py
+++ b/tests/test_managers/test_device_health.py
@@ -1,0 +1,87 @@
+"""Test device health tracking and maintenance backoff."""
+
+import unittest
+from unittest.mock import patch
+
+from pyinsteon.managers.device_health import (
+    BACKOFF_BASE,
+    BACKOFF_MAX,
+    FAILURE_BURST,
+    DeviceHealth,
+    get_health,
+)
+
+
+class TestDeviceHealth(unittest.TestCase):
+    """Test the DeviceHealth backoff behavior."""
+
+    def test_fresh_device_allows_maintenance(self):
+        """A device with no history is always allowed."""
+        health = DeviceHealth()
+        assert health.can_attempt_maintenance()
+
+    def test_burst_failures_do_not_back_off(self):
+        """Failures inside the burst allowance do not delay maintenance."""
+        health = DeviceHealth()
+        for _ in range(FAILURE_BURST - 1):
+            health.record_failure()
+        assert health.can_attempt_maintenance()
+
+    def test_backoff_engages_after_burst(self):
+        """Failures beyond the burst set a future maintenance time."""
+        health = DeviceHealth()
+        for _ in range(FAILURE_BURST):
+            health.record_failure()
+        assert not health.can_attempt_maintenance()
+
+    def test_backoff_grows_and_caps(self):
+        """Backoff grows exponentially and respects the cap."""
+        health = DeviceHealth()
+        with patch("pyinsteon.managers.device_health.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            mock_time.time.return_value = 1000.0
+            for _ in range(FAILURE_BURST + 20):
+                health.record_failure()
+            delay = health.next_maintenance - 1000.0
+            assert delay <= BACKOFF_MAX * 1.25
+            assert delay >= BACKOFF_MAX * 0.75
+
+    def test_first_backoff_near_base(self):
+        """The first post-burst backoff is near the base delay."""
+        health = DeviceHealth()
+        with patch("pyinsteon.managers.device_health.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            mock_time.time.return_value = 1000.0
+            for _ in range(FAILURE_BURST):
+                health.record_failure()
+            delay = health.next_maintenance - 1000.0
+            assert BACKOFF_BASE * 0.75 <= delay <= BACKOFF_BASE * 1.25
+
+    def test_heard_clears_backoff_keeps_failures(self):
+        """An inbound frame clears the timer but keeps failure history."""
+        health = DeviceHealth()
+        for _ in range(FAILURE_BURST + 2):
+            health.record_failure()
+        assert not health.can_attempt_maintenance()
+        health.heard()
+        assert health.can_attempt_maintenance()
+        assert health.consecutive_failures == FAILURE_BURST + 2
+
+    def test_success_resets_everything(self):
+        """A command success resets failures and backoff."""
+        health = DeviceHealth()
+        for _ in range(FAILURE_BURST + 2):
+            health.record_failure()
+        health.record_success()
+        assert health.consecutive_failures == 0
+        assert health.can_attempt_maintenance()
+
+    def test_registry_returns_same_instance(self):
+        """The registry returns one instance per address."""
+        h1 = get_health("aa.bb.cc")
+        h2 = get_health("AABBCC")
+        assert h1 is h2
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_managers/test_device_health.py
+++ b/tests/test_managers/test_device_health.py
@@ -57,15 +57,20 @@ class TestDeviceHealth(unittest.TestCase):
             delay = health.next_maintenance - 1000.0
             assert BACKOFF_BASE * 0.75 <= delay <= BACKOFF_BASE * 1.25
 
-    def test_heard_clears_backoff_keeps_failures(self):
-        """An inbound frame clears the timer but keeps failure history."""
+    def test_heard_does_not_clear_backoff(self):
+        """An inbound frame proves liveness but does not clear backoff.
+
+        Devices can ACK every request and never deliver data, so only a
+        completed operation or timer expiry reopens maintenance.
+        """
         health = DeviceHealth()
         for _ in range(FAILURE_BURST + 2):
             health.record_failure()
         assert not health.can_attempt_maintenance()
         health.heard()
-        assert health.can_attempt_maintenance()
+        assert not health.can_attempt_maintenance()
         assert health.consecutive_failures == FAILURE_BURST + 2
+        assert health.last_heard is not None
 
     def test_success_resets_everything(self):
         """A command success resets failures and backoff."""


### PR DESCRIPTION
# Description: 
Builds on #446  (the i3 ALDB read fix); the failure accounting in the read manager uses the erased-cell state that PR introduces.

A device that fails to answer can consume the powerline indefinitely. Watching my own network with an SDR I found three sources: ALDB reads retrying against a dead switch (875 frames in 20 minutes), extended property reads doing the same during startup (RETRIES = 20 per property group), and `_ping_device` pinging an unplugged modem address every 60 seconds for 1.5 days, relaunched on every restart. Repeated load requests also stack: each call to `ALDB.async_load` starts a new read against the same device.

There is a subtlety that shaped the design: two of my failing devices ACK every request but never deliver the data that was asked for. Counting transport ACKs as health would keep the retry storm alive forever, so the tracker counts operation outcomes instead.

# Changes:

- new `managers/device_health.py`: per-device failure count and a maintenance backoff window (60s doubling to a 1 hour cap, with jitter). Three failures start the backoff. Completed operations (a load reaching LOADED, a property  read succeeding) reset it; exhausted operations increment it; inbound frames update a last-heard timestamp but do not clear the backoff
- maintenance entry points check the window before sending: ALDB load, status requests, device ID, operating flag and extended property reads, and the unknown-device ping loop. User-initiated refresh loads bypass the entry check. Interactive device commands are never gated
- in-flight operations abort only at a much higher failure bar (4x the burst) so a long read on a lossy but live device is not cut short
- `ALDB.async_load` coalesces concurrent calls behind a per-device lock
- retry budgets trimmed where they multiplied the damage: ALDB single-record reads 20 to 5, extended property reads 20 to 5, peek byte retries 20 to 5
- the peek/poke fallback only engages for confirmed i1 engines that are currently responding. Previously any device that returned zero records got walked one byte at a time, which turned five failed reads into hundreds of sends

Healthy devices never hit any of this: the gates only engage after consecutive failures, and the full test suite passes unchanged. On my network the startup burst against a dead device dropped from continuous traffic to a bounded first pass, after which the device is retried about once an hour. Unit tests cover the backoff math and the operation-outcome accounting.
