### PR TITLE
Latch low battery until the device reports a good battery

### DIFF
--- a/pyinsteon/managers/low_batter_manager.py
+++ b/pyinsteon/managers/low_batter_manager.py
@@ -1,14 +1,9 @@
 """Low battery manager."""
 
-import asyncio
-
 from ..address import Address
 from ..handlers.from_device.off import OffInbound
 from ..handlers.from_device.on_level import OnLevelInbound
 from ..subscriber_base import SubscriberBase
-from ..utils import subscribe_topic
-
-WAIT_TIME = 5
 
 
 class LowBatteryManager(SubscriberBase):
@@ -31,40 +26,27 @@ class LowBatteryManager(SubscriberBase):
         self._on_low_battery = OnLevelInbound(self._address, self._group)
         self._off_low_battery = OffInbound(self._address, self._group)
         self._on_low_battery.subscribe(self._low_battery)
-        self._off_low_battery.subscribe(self._low_battery)
-        self._low_battery_recd = False
+        self._off_low_battery.subscribe(self._low_battery_clear)
         self._low_battery_state = False
         self._low_battery_event = self.LowBatterySubscriber(f"{subscriber_topic}.true")
         self._low_battery_clear_event = self.LowBatterySubscriber(
             f"{subscriber_topic}.false"
         )
-        subscribe_topic(self._all_device_messages, self._address.id)
 
     def subscribe_low_battery_event(self, callback):
         """Subscribe to low battery event."""
         self._low_battery_event.subscribe(callback)
 
     def subscribe_low_battery_clear_event(self, callback):
-        """Subscribe to low battery event."""
+        """Subscribe to low battery clear event."""
         self._low_battery_clear_event.subscribe(callback)
-
-    def _all_device_messages(self, **kwargs):
-        """Capture all messages for this device."""
-        loop = asyncio.get_event_loop()
-        target = kwargs.get("target")
-        # stop if this is a low battery message
-        if target and Address(target).low == self._group:
-            return
-        self._low_battery_recd = False
-        loop.call_later(WAIT_TIME, self._check_low_battery)
 
     def _low_battery(self, on_level):
         """Low battery message received."""
-        self._low_battery_recd = True
         self._low_battery_state = True
         self._low_battery_event.call_subscribers(low_battery=True)
 
-    def _check_low_battery(self):
-        """Check if a low battery message was received since the last message."""
-        if not self._low_battery_recd and self._low_battery_state:
-            self._low_battery_clear_event.call_subscribers(low_battery=False)
+    def _low_battery_clear(self, on_level):
+        """Good battery message received."""
+        self._low_battery_state = False
+        self._low_battery_clear_event.call_subscribers(low_battery=False)

--- a/tests/test_managers/test_low_battery_manager.py
+++ b/tests/test_managers/test_low_battery_manager.py
@@ -24,7 +24,6 @@ class TestLowBatteryManager(unittest.TestCase):
             logger_messages="info",
             logger_topics=False,
         )
-        pyinsteon.managers.low_batter_manager.WAIT_TIME = 0.05
         self._address = random_address()
         self._group = 3
         self._manager = pyinsteon.managers.low_batter_manager.LowBatteryManager(

--- a/tests/test_managers/test_low_battery_manager.py
+++ b/tests/test_managers/test_low_battery_manager.py
@@ -1,0 +1,127 @@
+"""Test the low battery manager."""
+
+import asyncio
+import unittest
+
+from pyinsteon.address import Address
+from pyinsteon.constants import MessageFlagType
+import pyinsteon.managers.low_batter_manager
+from pyinsteon.topics import OFF, ON
+from pyinsteon.utils import build_topic
+
+from tests import set_log_levels
+from tests.utils import TopicItem, async_case, random_address, send_topics
+
+
+class TestLowBatteryManager(unittest.TestCase):
+    """Test the low battery manager."""
+
+    async def async_setup(self):
+        """Set up the test."""
+        set_log_levels(
+            logger="info",
+            logger_pyinsteon="info",
+            logger_messages="info",
+            logger_topics=False,
+        )
+        pyinsteon.managers.low_batter_manager.WAIT_TIME = 0.05
+        self._address = random_address()
+        self._group = 3
+        self._manager = pyinsteon.managers.low_batter_manager.LowBatteryManager(
+            self._address, self._group
+        )
+        self._state_values = []
+        self._low_battery_events = []
+        self._clear_events = []
+        self._manager.subscribe(self.state_value)
+        self._manager.subscribe_low_battery_event(self.low_battery_event)
+        self._manager.subscribe_low_battery_clear_event(self.clear_event)
+        self._on_topic = build_topic(
+            ON, None, self._address, self._group, MessageFlagType.ALL_LINK_BROADCAST
+        )
+        self._off_topic = build_topic(
+            OFF, None, self._address, self._group, MessageFlagType.ALL_LINK_BROADCAST
+        )
+        self._other_topic = build_topic(
+            ON, None, self._address, 1, MessageFlagType.ALL_LINK_BROADCAST
+        )
+
+    def state_value(self, low_battery):
+        """Receive the low battery state."""
+        self._state_values.append(low_battery)
+
+    def low_battery_event(self, low_battery):
+        """Receive a low battery event."""
+        self._low_battery_events.append(low_battery)
+
+    def clear_event(self, low_battery):
+        """Receive a low battery clear event."""
+        self._clear_events.append(low_battery)
+
+    def _on_item(self, topic, group):
+        """Create an ON broadcast topic item."""
+        return TopicItem(
+            topic,
+            {
+                "cmd1": 0x11,
+                "cmd2": 0x00,
+                "target": Address(f"0000{group:02d}"),
+                "user_data": None,
+                "hops_left": 3,
+            },
+            0.02,
+        )
+
+    def _off_item(self):
+        """Create an OFF broadcast topic item."""
+        return TopicItem(
+            self._off_topic,
+            {
+                "cmd1": 0x13,
+                "cmd2": 0x00,
+                "target": Address(f"0000{self._group:02d}"),
+                "user_data": None,
+                "hops_left": 3,
+            },
+            0.02,
+        )
+
+    @async_case
+    async def test_low_battery_on(self):
+        """Test a group 3 ON broadcast sets low battery."""
+        await self.async_setup()
+        send_topics([self._on_item(self._on_topic, self._group)])
+        await asyncio.sleep(0.1)
+        assert self._low_battery_events == [True]
+        assert self._state_values == [True]
+        assert not self._clear_events
+
+    @async_case
+    async def test_good_battery_off_clears_low_battery(self):
+        """Test a group 3 OFF broadcast clears low battery."""
+        await self.async_setup()
+        send_topics([self._on_item(self._on_topic, self._group)])
+        await asyncio.sleep(0.1)
+        send_topics([self._off_item()])
+        await asyncio.sleep(0.1)
+        assert self._low_battery_events == [True]
+        assert self._clear_events == [False]
+        assert self._state_values == [True, False]
+
+    @async_case
+    async def test_unrelated_device_traffic_does_not_clear(self):
+        """Test messages from other groups do not clear low battery."""
+        await self.async_setup()
+        send_topics([self._on_item(self._on_topic, self._group)])
+        await asyncio.sleep(0.1)
+        send_topics([self._on_item(self._other_topic, 1)])
+        await asyncio.sleep(0.3)
+        send_topics([self._on_item(self._other_topic, 1)])
+        await asyncio.sleep(0.3)
+        assert self._low_battery_events == [True]
+        assert not self._clear_events
+        assert self._state_values == [True]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description:
Fixes the battery entity behavior reported in home-assistant/core#177426. A Hidden Door Sensor (2845-222) sent a low battery broadcast; the HA event fired and triggered the reporter's automation, but the battery entity showed Normal by the time anyone looked at it.

The cause is in `LowBatteryManager`. It subscribes to every message from the device and treats anything that is not a battery message as evidence the battery is fine, publishing a clear five seconds later. The cleanup traffic following the broadcast is enough to trigger this, so the Low state survives for about five seconds. Two more problems live in the same file. The group 3 OFF handler was subscribed to the low battery callback, so an explicit good-battery message (0x13) would set the state to Low. And the clear path never reset `_low_battery_state`, so after one low battery message every subsequent message from that device published another clear, forever. That last one is visible in the reporter's logs: dozens of battery devices on the network, but only the one that had reported low battery kept logging `low_battery: False` publishes.

These sensors already say what we need to know. Group 3 carries 0x11 for low battery and 0x13 for good battery (insteon-mqtt documents and handles it the same way), so the manager now reports what the device says and nothing else.

# Changes:
- group 3 OFF routes to a new clear handler that sets the state False and fires the clear event
- the low battery state latches until that OFF arrives; the guess-from-unrelated-traffic path (`_all_device_messages`, `_check_low_battery`, `WAIT_TIME`) is removed
- `_low_battery_state` resets on clear, which stops the repeated clear publishes
- tests for the manager, which had none: ON sets, OFF clears, unrelated traffic does not clear

One visible behavior change: after a battery swap the entity stays Low until the device sends its good-battery message or the stack restarts, instead of drifting back to Normal on the next unrelated message. That latch is the point of the fix.

The door sensor, motion sensor and smoke bridge device types all share this manager, so all three pick up the fix.
