### PR TITLE
publish releases to pypi from ci

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: python -m pip install build
+      - run: python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Publish releases to PyPI from CI.

- tag-driven: publishing a GitHub release builds the sdist and wheel and uploads them through PyPI trusted publishing (OIDC, no token secrets)
- `id-token: write` is scoped to the publish job only, build runs separately and hands artifacts over
- matches the pypa/gh-action-pypi-publish reference setup

Current releases are built and uploaded by hand from a dev machine, so PyPI shows no provenance for them. Once this merges I will configure the trusted publisher on PyPI (repo pyinsteon/pyinsteon, workflow publish.yml, environment pypi) so the next release goes out through CI with provenance attached. Also relevant for Home Assistant's quality scale work on the insteon integration, which checks that dependencies are published from public CI.
