### PR TITLE
Stop one missed record from blocking every modem write

### DIFF
--- a/pyinsteon/aldb/aldb_base.py
+++ b/pyinsteon/aldb/aldb_base.py
@@ -289,7 +289,8 @@ class ALDBBase(ABC):
         """Write the dirty records to the device."""
         if not self.is_loaded and not force:
             _LOGGER.warning(
-                "ALDB must be loaded before it can be written Status: %s",
+                "ALDB of %s must be loaded before it can be written Status: %s",
+                self._address,
                 str(self._status),
             )
             return 0, len(self._dirty_records)

--- a/pyinsteon/aldb/modem_aldb.py
+++ b/pyinsteon/aldb/modem_aldb.py
@@ -13,7 +13,6 @@ from .aldb_base import ALDBBase
 
 _LOGGER = logging.getLogger(__name__)
 MAX_MISSED_RECORDS = 3
-MAX_RECORDS = 512
 
 
 class ModemALDB(ALDBBase):
@@ -59,7 +58,16 @@ class ModemALDB(ALDBBase):
         async with self._load_lock:
             if waited and not refresh and self._status == ALDBStatus.LOADED:
                 return self._status
-            return await self._async_load()
+            previous_records = dict(self._records)
+            previous_status = self._status
+            previous_mem_addr = self._mem_addr
+            status = await self._async_load()
+            # A read that dies partway must not replace the last good set
+            if previous_records and status != ALDBStatus.LOADED:
+                self.load_saved_records(
+                    previous_status, previous_records, previous_mem_addr
+                )
+            return self._status
 
     async def _async_load(self):
         """Load the All-Link Database without reentrancy protection."""
@@ -104,17 +112,12 @@ class ModemALDB(ALDBBase):
     async def _async_load_eeprom(self):
         """Load using EEPROM read method."""
         _LOGGER.debug("Loading from EEPROM")
-        previous = self._records
         self._records = {}
         missed = []
         found_hwm = False
         mem_addr = self.first_mem_addr
 
-        while (
-            mem_addr > 0
-            and len(missed) < MAX_MISSED_RECORDS
-            and len(self._records) < MAX_RECORDS
-        ):
+        while mem_addr > 0 and len(missed) < MAX_MISSED_RECORDS:
             record = await self._read_manager.async_read_record(mem_addr)
             if record is None:
                 missed.append(mem_addr)
@@ -142,8 +145,6 @@ class ModemALDB(ALDBBase):
             self._address,
             ", ".join(f"0x{addr:04x}" for addr in missed) or "no high water mark found",
         )
-        if not found_hwm and len(previous) > len(self._records):
-            self._records = previous
 
     def _is_loaded(self):
         """Calculate the AlDB load status."""

--- a/pyinsteon/aldb/modem_aldb.py
+++ b/pyinsteon/aldb/modem_aldb.py
@@ -1,5 +1,6 @@
 """All-Link database for an Insteon Modem."""
 
+import asyncio
 import logging
 
 from .. import pub
@@ -11,7 +12,8 @@ from ..topics import ALL_LINK_RECORD_RESPONSE
 from .aldb_base import ALDBBase
 
 _LOGGER = logging.getLogger(__name__)
-MAX_RETRIES = 3
+MAX_MISSED_RECORDS = 3
+MAX_RECORDS = 512
 
 
 class ModemALDB(ALDBBase):
@@ -30,6 +32,7 @@ class ModemALDB(ALDBBase):
         super().__init__(address, version, mem_addr, write_manager=ImWriteManager)
 
         self._read_write_mode = ReadWriteMode.UNKNOWN
+        self._load_lock = asyncio.Lock()
         # If we are not the first modem, don't subscribe to
         mgr = pub.getDefaultTopicMgr()
         topic = mgr.getTopic(ALL_LINK_RECORD_RESPONSE, okIfNone=True)
@@ -46,12 +49,20 @@ class ModemALDB(ALDBBase):
         """Set the modem read mode."""
         self._read_write_mode = ReadWriteMode(value)
 
-    async def async_load(self, *args, **kwargs):
+    async def async_load(self, *args, refresh: bool = False, **kwargs):
         """Load the All-Link Database."""
 
         if self._read_manager is None:
-            return
+            return None
 
+        waited = self._load_lock.locked()
+        async with self._load_lock:
+            if waited and not refresh and self._status == ALDBStatus.LOADED:
+                return self._status
+            return await self._async_load()
+
+    async def _async_load(self):
+        """Load the All-Link Database without reentrancy protection."""
         self._update_status(ALDBStatus.LOADING)
         # See if we can use EEPROM reads
         if self._read_write_mode == ReadWriteMode.UNKNOWN:
@@ -93,16 +104,46 @@ class ModemALDB(ALDBBase):
     async def _async_load_eeprom(self):
         """Load using EEPROM read method."""
         _LOGGER.debug("Loading from EEPROM")
-        next_mem_addr = self.first_mem_addr
+        previous = self._records
         self._records = {}
-        record = await self._read_manager.async_read_record(next_mem_addr)
-        while record:
-            self._records[record.mem_addr] = record
+        missed = []
+        found_hwm = False
+        mem_addr = self.first_mem_addr
+
+        while (
+            mem_addr > 0
+            and len(missed) < MAX_MISSED_RECORDS
+            and len(self._records) < MAX_RECORDS
+        ):
+            record = await self._read_manager.async_read_record(mem_addr)
+            if record is None:
+                missed.append(mem_addr)
+            else:
+                self._records[mem_addr] = record
+                self._notify_change(record)
+                if record.is_high_water_mark:
+                    found_hwm = True
+                    break
+            mem_addr -= 8
+
+        for mem_addr in list(missed):
+            record = await self._read_manager.async_read_record(mem_addr)
+            if record is None:
+                continue
+            missed.remove(mem_addr)
+            self._records[mem_addr] = record
             self._notify_change(record)
-            if record.is_high_water_mark:
-                return
-            record = await self._read_manager.async_read_record(next_mem_addr)
-            next_mem_addr -= 8
+
+        if found_hwm and not missed:
+            return
+
+        _LOGGER.warning(
+            "Modem %s ALDB is incomplete: %s",
+            self._address,
+            ", ".join(f"0x{addr:04x}" for addr in missed) or "no high water mark found",
+        )
+        if not found_hwm and len(previous) > len(self._records):
+            self._records = previous
 
     def _is_loaded(self):
         """Calculate the AlDB load status."""

--- a/pyinsteon/managers/aldb_im_read_manager.py
+++ b/pyinsteon/managers/aldb_im_read_manager.py
@@ -19,6 +19,8 @@ from ..topics import ALL_LINK_RECORD_RESPONSE
 
 _LOGGER = logging.getLogger(__name__)
 TIMEOUT = 2
+RETRIES = 3
+RETRY_WAIT = 0.5
 
 
 class ImReadManager:
@@ -37,7 +39,6 @@ class ImReadManager:
             self._receive_record_handler.subscribe(self._receive_record)
             self._receive_eeprom_record_handler = ReadEepromResponseHandler()
             self._receive_eeprom_record_handler.subscribe(self._receive_eeprom_record)
-        self._retries = 0
         self._load_lock = asyncio.Lock()
         self._record_queue = asyncio.Queue()
 
@@ -51,21 +52,6 @@ class ImReadManager:
             return
         async for record in self.async_get_next_all_link_records():
             yield record
-
-    async def async_load_eeprom(self):
-        """Load the Insteon modem ALDB using EEPROM reads."""
-        self._clear_read_queue()
-        next_mem_addr = self._aldb.first_mem_addr
-        record = await self.async_read_record(next_mem_addr)
-        if record:
-            yield record
-        else:
-            return
-        for record in await self.async_read_record(next_mem_addr):
-            yield record
-            if record.is_high_water_mark:
-                return
-            next_mem_addr -= 8
 
     async def async_get_first_all_link_record(self):
         """Get the first All-Link database record."""
@@ -118,19 +104,32 @@ class ImReadManager:
     async def async_read_record(self, mem_addr: int) -> ALDBRecord:
         """Read from EEPROM."""
         self._clear_read_queue()
-        retries = 20
         cmd = ReadEepromHandler()
-        response = None
-        while retries and response != ResponseStatus.SUCCESS:
+        for attempt in range(RETRIES):
             response = await cmd.async_send(mem_addr=mem_addr)
-            retries -= 1
             if response == ResponseStatus.SUCCESS:
-                try:
-                    async with async_timeout.timeout(TIMEOUT):
-                        return await self._record_queue.get()
-                except asyncio.TimeoutError:
-                    return None
-            await asyncio.sleep(0.5)
+                record = await self._async_next_record(mem_addr)
+                if record:
+                    return record
+            if attempt < RETRIES - 1:
+                await asyncio.sleep(RETRY_WAIT)
+        return None
+
+    async def _async_next_record(self, mem_addr: int) -> ALDBRecord:
+        """Return the queued record for mem_addr, discarding any other."""
+        try:
+            async with async_timeout.timeout(TIMEOUT):
+                while True:
+                    record = await self._record_queue.get()
+                    if record.mem_addr == mem_addr:
+                        return record
+                    _LOGGER.debug(
+                        "Modem read of 0x%04x answered with 0x%04x",
+                        mem_addr,
+                        record.mem_addr,
+                    )
+        except asyncio.TimeoutError:
+            return None
 
     async def async_confirm_eeprom_read(self) -> int:
         """Confirm the first memory address is readable with an EEPROM read.
@@ -154,8 +153,12 @@ class ImReadManager:
                 if eeprom_record:
                     break
 
-            if first_record is None and eeprom_record.is_high_water_mark:
-                return eeprom_record.mem_addr  # ALDB is empty
+            if eeprom_record is None:
+                return 0
+
+            if first_record is None:
+                # A high water mark with no first record means the ALDB is empty
+                return eeprom_record.mem_addr if eeprom_record.is_high_water_mark else 0
 
             if first_record.is_exact_match(eeprom_record):
                 return eeprom_record.mem_addr

--- a/pyinsteon/managers/device_manager.py
+++ b/pyinsteon/managers/device_manager.py
@@ -313,10 +313,8 @@ class DeviceManager(SubscriberBase):
             load_modem_aldb: Indicate if the Modem ALDB should be loaded
                 0: Do not load
                 1: Load if not loaded from save file
-                2: Load
+                2: Always load
             (default=1)
-
-        The Modem ALDB is loaded if `refresh` is True or if the saved file has no devices.
 
         """
         if workdir:
@@ -326,6 +324,7 @@ class DeviceManager(SubscriberBase):
                 for address in devices:
                     self[address] = devices[address]
 
+        force_modem_aldb = load_modem_aldb == 2
         if load_modem_aldb == 0:
             load_modem_aldb = False
         elif load_modem_aldb == 2:
@@ -334,7 +333,7 @@ class DeviceManager(SubscriberBase):
             load_modem_aldb = not self._modem.aldb.is_loaded
 
         if load_modem_aldb:
-            await self._modem.aldb.async_load()
+            await self._modem.aldb.async_load(refresh=force_modem_aldb)
 
         for mem_addr in self._modem.aldb:
             rec = self._modem.aldb[mem_addr]

--- a/tests/test_aldb/test_modem_aldb.py
+++ b/tests/test_aldb/test_modem_aldb.py
@@ -1,13 +1,82 @@
 """Test the modem ALDB."""
 
+# pylint: disable=protected-access
+import asyncio
 from unittest import TestCase
 from pyinsteon import pub
+from pyinsteon.address import Address
 from pyinsteon.aldb import modem_aldb
+from pyinsteon.aldb.aldb_record import ALDBRecord
+from pyinsteon.constants import ALDBStatus, ReadWriteMode
 from pyinsteon.topics import ALL_LINK_RECORD_RESPONSE
 
 from pyinsteon.aldb.modem_aldb import ModemALDB
 
 from ..utils import async_case, random_address
+
+
+def _record(mem_addr, high_water_mark=False):
+    return ALDBRecord(
+        memory=mem_addr,
+        controller=not high_water_mark,
+        group=0 if high_water_mark else 1,
+        target=Address("000000" if high_water_mark else "aabbcc"),
+        data1=0,
+        data2=0,
+        data3=0,
+        in_use=not high_water_mark,
+        high_water_mark=high_water_mark,
+    )
+
+
+class MockEepromReader:
+    """Serve modem EEPROM records and fail the addresses it is told to."""
+
+    def __init__(self, hwm_addr=0x1FE7, fail_once=None, fail_always=None):
+        """Init the MockEepromReader class."""
+        self.hwm_addr = hwm_addr
+        self.fail_once = set(fail_once or [])
+        self.fail_always = set(fail_always or [])
+        self.reads = []
+
+    async def async_read_record(self, mem_addr):
+        """Return the record at mem_addr."""
+        self.reads.append(mem_addr)
+        if mem_addr in self.fail_always:
+            return None
+        if mem_addr in self.fail_once:
+            self.fail_once.remove(mem_addr)
+            return None
+        if mem_addr < self.hwm_addr:
+            return None
+        return _record(mem_addr, high_water_mark=mem_addr == self.hwm_addr)
+
+
+class GatedEepromReader(MockEepromReader):
+    """Hold every read until released."""
+
+    def __init__(self, **kwargs):
+        """Init the GatedEepromReader class."""
+        super().__init__(**kwargs)
+        self.release = asyncio.Event()
+
+    async def async_read_record(self, mem_addr):
+        """Return the record at mem_addr once released."""
+        await self.release.wait()
+        return await super().async_read_record(mem_addr)
+
+
+# pypubsub holds weak references to the subscribed handlers
+_SUBSCRIBED = []
+
+
+def _eeprom_aldb(reader):
+    aldb = ModemALDB(random_address(), mem_addr=0x1FFF)
+    if aldb._read_manager is not None:
+        _SUBSCRIBED.append(aldb._read_manager)
+    aldb._read_write_mode = ReadWriteMode.EEPROM
+    aldb._read_manager = reader
+    return aldb
 
 
 class TestModemALDB(TestCase):
@@ -41,3 +110,67 @@ class TestModemALDB(TestCase):
         topic = mgr.getTopic(ALL_LINK_RECORD_RESPONSE)
         listeners = topic.getListeners()
         assert len(listeners) == 1
+
+    @async_case
+    async def test_missed_record_is_reread(self):
+        """Test a record that fails once is read again."""
+        reader = MockEepromReader(fail_once=[0x1FF7])
+        aldb = _eeprom_aldb(reader)
+
+        await aldb._async_load()
+
+        assert aldb.status == ALDBStatus.LOADED
+        assert sorted(aldb) == [0x1FE7, 0x1FEF, 0x1FF7, 0x1FFF]
+        assert reader.reads.count(0x1FF7) == 2
+
+    @async_case
+    async def test_unreadable_record_does_not_end_the_walk(self):
+        """Test the walk continues past a record that never reads."""
+        reader = MockEepromReader(fail_always=[0x1FF7])
+        aldb = _eeprom_aldb(reader)
+
+        await aldb._async_load()
+
+        assert aldb.status == ALDBStatus.PARTIAL
+        assert 0x1FF7 not in aldb
+        assert 0x1FE7 in aldb
+
+    @async_case
+    async def test_walk_stops_at_the_high_water_mark(self):
+        """Test no record below the high water mark is stored."""
+        reader = MockEepromReader()
+        aldb = _eeprom_aldb(reader)
+
+        await aldb._async_load()
+
+        assert aldb.status == ALDBStatus.LOADED
+        assert min(aldb) == 0x1FE7
+        assert 0x1FDF not in reader.reads
+
+    @async_case
+    async def test_incomplete_read_keeps_the_saved_records(self):
+        """Test a read with no high water mark leaves the saved records alone."""
+        saved = {addr: _record(addr) for addr in (0x1FFF, 0x1FF7, 0x1FEF)}
+        saved[0x1FE7] = _record(0x1FE7, high_water_mark=True)
+        reader = MockEepromReader(fail_always=[0x1FFF, 0x1FF7, 0x1FEF])
+        aldb = _eeprom_aldb(reader)
+        aldb.load_saved_records(ALDBStatus.LOADED, saved)
+
+        await aldb._async_load()
+
+        assert len(aldb) == 4
+
+    @async_case
+    async def test_concurrent_loads_read_once(self):
+        """Test a second load does not repeat a finished read."""
+        reader = GatedEepromReader()
+        aldb = _eeprom_aldb(reader)
+
+        first = asyncio.ensure_future(aldb.async_load())
+        second = asyncio.ensure_future(aldb.async_load())
+        await asyncio.sleep(0.01)
+        reader.release.set()
+        await asyncio.gather(first, second)
+
+        assert aldb.status == ALDBStatus.LOADED
+        assert reader.reads == [0x1FFF, 0x1FF7, 0x1FEF, 0x1FE7]

--- a/tests/test_aldb/test_modem_aldb.py
+++ b/tests/test_aldb/test_modem_aldb.py
@@ -117,7 +117,7 @@ class TestModemALDB(TestCase):
         reader = MockEepromReader(fail_once=[0x1FF7])
         aldb = _eeprom_aldb(reader)
 
-        await aldb._async_load()
+        await aldb.async_load()
 
         assert aldb.status == ALDBStatus.LOADED
         assert sorted(aldb) == [0x1FE7, 0x1FEF, 0x1FF7, 0x1FFF]
@@ -129,7 +129,7 @@ class TestModemALDB(TestCase):
         reader = MockEepromReader(fail_always=[0x1FF7])
         aldb = _eeprom_aldb(reader)
 
-        await aldb._async_load()
+        await aldb.async_load()
 
         assert aldb.status == ALDBStatus.PARTIAL
         assert 0x1FF7 not in aldb
@@ -141,7 +141,7 @@ class TestModemALDB(TestCase):
         reader = MockEepromReader()
         aldb = _eeprom_aldb(reader)
 
-        await aldb._async_load()
+        await aldb.async_load()
 
         assert aldb.status == ALDBStatus.LOADED
         assert min(aldb) == 0x1FE7
@@ -156,9 +156,35 @@ class TestModemALDB(TestCase):
         aldb = _eeprom_aldb(reader)
         aldb.load_saved_records(ALDBStatus.LOADED, saved)
 
-        await aldb._async_load()
+        await aldb.async_load()
 
         assert len(aldb) == 4
+
+    @async_case
+    async def test_incomplete_read_keeps_an_equal_sized_saved_set(self):
+        """Test a same size read with no high water mark keeps the saved records."""
+        saved = {
+            addr: ALDBRecord(
+                memory=addr,
+                controller=True,
+                group=7,
+                target=Address("010203"),
+                data1=0,
+                data2=0,
+                data3=0,
+                in_use=True,
+                high_water_mark=False,
+            )
+            for addr in (0x1FFF, 0x1FF7)
+        }
+        reader = MockEepromReader(fail_always=[0x1FEF, 0x1FE7, 0x1FDF])
+        aldb = _eeprom_aldb(reader)
+        aldb.load_saved_records(ALDBStatus.LOADED, saved)
+
+        await aldb.async_load()
+
+        assert len(aldb) == 2
+        assert all(aldb[addr].group == 7 for addr in aldb)
 
     @async_case
     async def test_concurrent_loads_read_once(self):


### PR DESCRIPTION
# Description:
One record missing out of 135 in my PLM's ALDB was enough to block every modem side write on the network, with no error anywhere.

`ALDBBase._is_loaded` wants the record addresses to descend in steps of 8, so a single gap means `is_loaded` is false forever. `async_write` checks that first and returns `(0, dirty)` after logging a warning that did not say which device it was about. So the modem half of add device, the modem half of remove device and every scene write did nothing and reported nothing. The device half of the same operation writes fine, which leaves a one sided link for `get_broken_links` to report later as a missing controller.

The gap comes out of the EEPROM read path. `ImReadManager.async_read_record` returns whatever record is first off a shared queue without checking that it answers the address it just asked for, and `_async_load_eeprom` files the record under the address the modem reported rather than the one requested. One duplicate or late 0x59 puts the walk a step out of phase. While it is out of phase every record still lands under a correct key, so nothing looks wrong, and when the phase corrects, the record sitting in the queue at that moment gets dropped by `_clear_read_queue()` and that address is gone. Nothing goes back for it. `while record:` made it worse by ending the whole walk on the first read that came back empty, and the short result was then saved over the good one.

On my network the missing address was 0x1C2F, between 0x1C37 and 0x1C27, in an otherwise contiguous 135 record database with the high water mark present at 0x1BC7. Forcing a reload read it back on the first try, a responder record for group 1 to 17.30.B7, and the database went to 136 records and LOADED. So the cell was always readable and the hole was a transient that nothing ever repaired. I could not get it to happen again on hardware, 137 requests and 137 responses on the clean reload with every address matching, so the out of phase sequence is reproduced in the tests by delivering one duplicate response.

# Changes:

- `async_read_record` compares the returned record's address against the one it asked for and discards anything else inside the same timeout window, then retries the send. `RETRIES` is 3 with a 0.5s wait, replacing `retries = 20` that only ever covered the send and gave up on the record after one timeout
- `_async_load_eeprom` notes an unread cell instead of ending the walk, carries on to the high water mark, then re-reads what it missed. `MAX_MISSED_RECORDS` (3) and `MAX_RECORDS` (512) bound it so a modem that stops answering cannot walk the address space
- a walk that never finds a high water mark no longer replaces a larger saved set. Without this the first flaky read after this lands puts you straight back into silent write refusal
- `ModemALDB.async_load` gets the `_load_lock` and the waited/refresh check `ALDB.async_load` already has. `device_manager` passes `refresh=True` for `load_modem_aldb=2` so "always load" still means always once the lock can skip a finished load
- the write refused warning names the device. Not naming it is most of why this sat there unnoticed
- dead code out: `ImReadManager.async_load_eeprom` (nothing calls it, and it reads the same address twice and then loops over the record it got back instead of over records, so the first `is_high_water_mark` would hit a tuple), the unused `_retries`, and `MAX_RETRIES` in `modem_aldb`
- `async_confirm_eeprom_read` guards two None dereferences. The correlation check makes a None return more likely, and an `AttributeError` there leaves the modem pinned at LOADING for the life of the process

Five tests on the modem walk, which had none before: a record that fails once is re-read, a cell that never answers does not truncate the walk, the walk stops at the high water mark, an incomplete read keeps the saved records, and two concurrent loads read once.

Full suite on 3.14 is 558 tests, all green. pylint, flake8 and black are clean on 3.11 with the pinned versions. A clean 136 record load is now one read per record, about 70 seconds at the 0.5s write wait; the old walk read the first address twice.

home-assistant/core#178299 and pyinsteon/insteon-panel#57 look like the modem side of add device failing quietly, which would be this.
