### PR TITLE
Stop retrying forever when a device answers with other records

### DIFF
--- a/pyinsteon/managers/aldb_read_manager.py
+++ b/pyinsteon/managers/aldb_read_manager.py
@@ -135,34 +135,39 @@ class ALDBReadManager:
                     response,
                 )
                 return None
-            try:
-                async with async_timeout.timeout(TIMER_RECORD):
+            record = await self._async_matching_record(mem_addr)
+            if record is not None or self._hit_erased or not self._continue:
+                return record
+            retries -= 1
+            await asyncio.sleep(0.1)
+        _LOGGER.debug("_read_one completed")
+        if self._continue and not self._hit_erased:
+            get_health(self._address).record_failure()
+        return None
+
+    async def _async_matching_record(self, mem_addr):
+        """Return the queued record for mem_addr, discarding any other."""
+        try:
+            async with async_timeout.timeout(TIMER_RECORD):
+                while True:
                     record = await self._record_queue.get()
-                    if (
-                        record is not None
-                        and is_erased_record(record)
-                        and mem_addr in (record.mem_addr, 0x0000)
+                    if record is None:
+                        return None
+                    if is_erased_record(record) and mem_addr in (
+                        record.mem_addr,
+                        0x0000,
                     ):
                         self._hit_erased = True
                         _LOGGER.debug(
                             "_read_one got erased cell 0x%04X", record.mem_addr
                         )
                         return None
-                    if (
-                        record is not None
-                        and record.mem_addr == mem_addr
-                        or mem_addr == 0x0000
-                    ):
+                    if mem_addr in (record.mem_addr, 0x0000):
                         _LOGGER.debug("_read_one returning record: %s", str(record))
                         return record
                     _LOGGER.debug("_read_one not returning record: %s", str(record))
-            except asyncio.TimeoutError:
-                retries -= 1
-            await asyncio.sleep(0.1)
-        _LOGGER.debug("_read_one completed")
-        if self._continue and not self._hit_erased:
-            get_health(self._address).record_failure()
-        return None
+        except asyncio.TimeoutError:
+            return None
 
     async def _read_one_peek(self, mem_addr):
         """Read one record using peek commands."""

--- a/tests/test_managers/test_aldb_read_manager.py
+++ b/tests/test_managers/test_aldb_read_manager.py
@@ -6,11 +6,14 @@ import unittest
 
 import async_timeout
 
+from unittest.mock import patch
+
 from pyinsteon.address import Address
 from pyinsteon.aldb.aldb_record import ALDBRecord
-from pyinsteon.constants import ReadWriteMode
+from pyinsteon.constants import ReadWriteMode, ResponseStatus
 from pyinsteon.data_types.user_data import UserData
-from pyinsteon.managers.aldb_read_manager import ALDBReadManager
+from pyinsteon.managers import aldb_read_manager
+from pyinsteon.managers.aldb_read_manager import RETRIES_ONE_MAX, ALDBReadManager
 from pyinsteon.topics import EXTENDED_READ_WRITE_ALDB, PEEK, SET_ADDRESS_MSB
 
 from tests import set_log_levels
@@ -401,3 +404,34 @@ class TestAldbReadManager(unittest.TestCase):
                     assert False
             except asyncio.TimeoutError:
                 assert False
+
+    @async_case
+    async def test_read_one_stops_on_records_for_other_addresses(self):
+        """Test a stream of records for other addresses does not retry forever."""
+        address = random_address()
+        mgr = ALDBReadManager(address=address, first_record=0x0FFF)
+        sends = []
+
+        async def _send(mem_addr, num_recs):
+            sends.append(mem_addr)
+            for offset in range(1, 4):
+                mgr._record_queue.put_nowait(
+                    ALDBRecord(
+                        memory=mem_addr - offset * 8,
+                        controller=True,
+                        group=0,
+                        target=random_address(),
+                        data1=0,
+                        data2=0,
+                        data3=0,
+                    )
+                )
+            return ResponseStatus.SUCCESS
+
+        mgr._read_handler.async_send = _send
+        with patch.object(aldb_read_manager, "TIMER_RECORD", 0.1):
+            async with async_timeout.timeout(10):
+                record = await mgr._read_one(0x0FFF)
+
+        assert record is None
+        assert len(sends) == RETRIES_ONE_MAX


### PR DESCRIPTION
# Description:
A device that answers an ALDB read with records for other addresses keeps the read loop running forever. I hit this on my own network today: one i3 Outlet put 603 record responses on the powerline over about seven and a half minutes, and the only thing that stopped it was killing Home Assistant.

`_read_one` sets `retries = RETRIES_ONE_MAX` and then decrements it in exactly one place, the `except asyncio.TimeoutError` branch. A record that arrives but does not answer the address we asked for falls out of the `try`, sleeps 100ms, and goes round again to re-send the same request. As long as the device keeps producing anything at all the read never times out, so `retries` never drops and `while retries` never ends. My log has 78 identical sends of `read 0x0FF7 num_recs=1` at a 6.1s cadence, each one about 100ms after a "not returning record" line. It should have been five sends and a clean exit.

`record_failure()` sits after the loop, so the maintenance backoff cannot help either. It never gets reached.

The device turned out to be genuinely faulty. Its ALDB had lost the high water mark, so its own firmware had no stop condition and it was streaming erased cells on its own: 165 frames arrived in 85 seconds before I sent it anything, and the frames are anti-correlated with my requests, so it pauses to take a command and then carries on. Re-pairing the outlet fixed the device and it now reads 11 records in a few seconds. But a broken device should cost five reads, not seven minutes of airtime, and that part is ours.

Worth saying that 592 of those 603 frames pass the extended message checksum, so this is not line noise. The device really did send them.

# Changes:

- the queue drain moves into `_async_matching_record`, which discards records for other addresses inside one timeout window instead of re-sending for each one
- `retries` decrements on every attempt, not only on a timeout, so a device that answers with the wrong thing is bounded at `RETRIES_ONE_MAX` sends like one that answers with nothing
- the erased-cell and stop-sentinel paths are unchanged. A `None` off the queue still means stop, and hitting an erased cell still ends the read the way #446 set up
- one latent bug fixed on the way: `record is not None and record.mem_addr == mem_addr or mem_addr == 0x0000` parses as `(a and b) or c`, so the `mem_addr == 0` wildcard could return a `None` record to the caller

The new test feeds the manager records for other addresses and asserts the send count. It passes on this branch and hangs until a 10 second guard fires on dev, which is the loop.

Full suite 554 on 3.14, and pylint, flake8 and black are clean on 3.11 with the pinned versions.

Related: #454 fixes the same shape on the modem side, where an out of phase 0x59 response cost one record permanently. Different files and no dependency between them, but the same idea: only accept a read that answers what was asked, and give every ask a bounded budget.
