### PR TITLE
Fix how the device cache is written and read back

### DIFF
--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -45,9 +45,18 @@ class ALDB(ALDBBase):
             # A refresh is not; the caller asked for a fresh read.
             if waited and not refresh and self._status == ALDBStatus.LOADED:
                 return self._status
-            return await self._async_load(
+            previous_records = dict(self._records) if refresh else {}
+            previous_status = self._status
+            previous_mem_addr = self._mem_addr
+            status = await self._async_load(
                 mem_addr=mem_addr, num_recs=num_recs, refresh=refresh
             )
+            # A refresh that dies partway must not replace the last good set
+            if refresh and previous_records and status != ALDBStatus.LOADED:
+                self.load_saved_records(
+                    previous_status, previous_records, previous_mem_addr
+                )
+            return self._status
 
     async def _async_load(
         self, mem_addr: int = 0x00, num_recs: int = 0x00, refresh: bool = False

--- a/pyinsteon/aldb/aldb_base.py
+++ b/pyinsteon/aldb/aldb_base.py
@@ -209,6 +209,13 @@ class ALDBBase(ABC):
         if first_mem_addr is not None:
             self._mem_addr = first_mem_addr
 
+        # A saved LOADING is a read that never finished; for a device, a
+        # saved LOADED with no records is one that never happened
+        status = ALDBStatus(int(status))
+        if status == ALDBStatus.LOADING:
+            status = ALDBStatus.PARTIAL if self._records else ALDBStatus.EMPTY
+        elif status == ALDBStatus.LOADED and not self._records:
+            status = ALDBStatus.EMPTY
         self._update_status(status)
 
     def add(

--- a/pyinsteon/aldb/modem_aldb.py
+++ b/pyinsteon/aldb/modem_aldb.py
@@ -64,9 +64,11 @@ class ModemALDB(ALDBBase):
             status = await self._async_load()
             # A read that dies partway must not replace the last good set
             if previous_records and status != ALDBStatus.LOADED:
+                pending = self._dirty_records
                 self.load_saved_records(
                     previous_status, previous_records, previous_mem_addr
                 )
+                self._dirty_records = pending
             return self._status
 
     async def _async_load(self):

--- a/pyinsteon/managers/aldb_im_write_manager.py
+++ b/pyinsteon/managers/aldb_im_write_manager.py
@@ -94,18 +94,16 @@ class ImWriteManager:
         self, record
     ) -> Tuple[ResponseStatus, ALDBRecord]:
         """Write a deleted record."""
-        matching_recs = await self._aldb.async_find_records(
-            target=record.target, group=record.group
-        )
         rec_to_delete = None
-        for rec in matching_recs:
+        async for rec in self._aldb.async_find_records(record.target, record.group):
             if rec.is_controller == record.is_controller:
                 rec_to_delete = rec
                 break
         if rec_to_delete:
-            return self._async_write_record_standard(
-                rec_to_delete, ManageAllLinkRecordAction.DELETE_FIRST
+            return await self._async_write_record_standard(
+                ManageAllLinkRecordAction.DELETE_FIRST, rec_to_delete
             )
+        return ResponseStatus.FAILURE
 
     async def _async_write_record_standard(
         self, action, record

--- a/pyinsteon/managers/link_manager/__init__.py
+++ b/pyinsteon/managers/link_manager/__init__.py
@@ -10,6 +10,7 @@ import async_timeout
 
 from ...address import Address
 from ...aldb.aldb_record import ALDBRecord
+from ...aldb.no_aldb import NoALDB
 from ...constants import AllLinkMode, EngineVersion, LinkStatus, ResponseStatus
 from ...handlers.cancel_all_linking import CancelAllLinkingCommandHandler
 from ...handlers.start_all_linking import StartAllLinkingCommandHandler
@@ -246,13 +247,18 @@ def _test_broken(address: Address, rec: ALDBRecord, devices: List[Device]):
     if not device:
         return LinkStatus.MISSING_TARGET
 
+    # A Range Extender or other device with no ALDB cannot hold the other half
+    if isinstance(device.aldb, NoALDB):
+        return LinkStatus.FOUND
+
     if not device.aldb.is_loaded:
         return LinkStatus.TARGET_DB_NOT_LOADED
 
     for mem_addr in device.aldb:
         t_rec = device.aldb[mem_addr]
         if (
-            t_rec.target == address
+            t_rec.is_in_use
+            and t_rec.target == address
             and t_rec.group == rec.group
             and t_rec.is_controller != rec.is_controller
         ):

--- a/pyinsteon/managers/saved_devices_manager.py
+++ b/pyinsteon/managers/saved_devices_manager.py
@@ -1,11 +1,13 @@
 """Manage saving and restoring devices from JSON file."""
 
+import asyncio
 import json
 import logging
-from os import path
+import os
 from typing import Dict
 
 import aiofiles
+import aiofiles.os
 
 from ..address import Address
 from ..aldb.aldb_record import ALDBRecord
@@ -18,6 +20,8 @@ from .utils import create_device
 DEVICE_INFO_FILE = "insteon_devices.json"
 OLD_DEVICE_INFO_FILE = "insteon_plm_device_info.dat"
 _LOGGER = logging.getLogger(__name__)
+# A new SavedDeviceManager is created per save, so the lock must outlive it.
+_SAVE_LOCK = asyncio.Lock()
 
 
 def aldb_rec_to_dict(rec):
@@ -273,14 +277,23 @@ class SavedDeviceManager:
             return saved_devices
 
         try:
-            device_file = path.join(self._workdir, DEVICE_INFO_FILE)
+            device_file = os.path.join(self._workdir, DEVICE_INFO_FILE)
             async with aiofiles.open(device_file, "r") as afp:
                 json_file = ""
                 json_file = await afp.read()
             try:
                 saved_devices = json.loads(json_file)
             except json.decoder.JSONDecodeError:
-                _LOGGER.debug("Loading saved device file failed")
+                corrupt_file = f"{device_file}.corrupt"
+                _LOGGER.error(
+                    "Saved device file %s is corrupt; moving it to %s",
+                    device_file,
+                    corrupt_file,
+                )
+                try:
+                    await aiofiles.os.replace(device_file, corrupt_file)
+                except OSError as ex:
+                    _LOGGER.error("Cannot move the corrupt device file: %s", ex)
         except FileNotFoundError:
             _LOGGER.debug("Saved device file not found")
             saved_devices = await self._read_old_device_file()
@@ -288,15 +301,21 @@ class SavedDeviceManager:
 
     async def _write_saved_devices(self, device_list):
         _LOGGER.debug("Writing %d devices to save file", len(device_list))
-        device_file = path.join(self._workdir, DEVICE_INFO_FILE)
-        try:
-            async with aiofiles.open(device_file, "w") as afp:
-                out_json = json.dumps(device_list, indent=2)
-                await afp.write(out_json)
-                await afp.flush()
-        except FileNotFoundError as ex:
-            _LOGGER.error("Cannot write to file %s", device_file)
-            _LOGGER.error("Exception: %s", str(ex))
+        device_file = os.path.join(self._workdir, DEVICE_INFO_FILE)
+        temp_file = f"{device_file}.tmp"
+        out_json = json.dumps(device_list, indent=2)
+        async with _SAVE_LOCK:
+            try:
+                async with aiofiles.open(temp_file, "w") as afp:
+                    await afp.write(out_json)
+                    await afp.flush()
+                    await asyncio.get_running_loop().run_in_executor(
+                        None, os.fsync, afp.fileno()
+                    )
+                await aiofiles.os.replace(temp_file, device_file)
+            except OSError as ex:
+                _LOGGER.error("Cannot write to file %s", device_file)
+                _LOGGER.error("Exception: %s", str(ex))
 
     async def _read_old_device_file(self):
         """Load device information from the insteonplm device info file."""
@@ -308,7 +327,7 @@ class SavedDeviceManager:
             return saved_devices
 
         try:
-            device_file = path.join(self._workdir, OLD_DEVICE_INFO_FILE)
+            device_file = os.path.join(self._workdir, OLD_DEVICE_INFO_FILE)
             async with aiofiles.open(device_file, "r") as afp:
                 json_file = ""
                 json_file = await afp.read()

--- a/pyinsteon/managers/saved_devices_manager.py
+++ b/pyinsteon/managers/saved_devices_manager.py
@@ -11,7 +11,7 @@ import aiofiles.os
 
 from ..address import Address
 from ..aldb.aldb_record import ALDBRecord
-from ..constants import EngineVersion
+from ..constants import ALDBStatus, EngineVersion
 from ..device_types.device_base import Device
 from ..x10_address import X10Address
 from .device_id_manager import DeviceId
@@ -90,13 +90,16 @@ def _device_to_dict(device_list):
             properties = {}
             for flag in device.properties:
                 properties[flag] = device.properties[flag].value
+            aldb_status = device.aldb.status
+            if aldb_status == ALDBStatus.LOADING:
+                aldb_status = ALDBStatus.PARTIAL if aldb else ALDBStatus.EMPTY
             device_info = {
                 "address": device.address.id,
                 "cat": device.cat,
                 "subcat": device.subcat,
                 "firmware": device.firmware,
                 "engine_version": int(device.engine_version),
-                "aldb_status": device.aldb.status.value,
+                "aldb_status": aldb_status.value,
                 "aldb": aldb,
                 "operating_flags": operating_flags,
                 "properties": properties,

--- a/tests/test_aldb/test_aldb_base.py
+++ b/tests/test_aldb/test_aldb_base.py
@@ -216,6 +216,22 @@ class TestAldbBase(TestCase):
         assert aldb.is_loaded
 
     @async_case
+    async def test_load_saved_records_transient_status(self):
+        """Test that a saved transient status is not replayed verbatim."""
+        address = random_address()
+        aldb = ALDB(address)
+
+        incomplete = {0x0FFF: records[0x0FFF], 0x0FF7: records[0x0FF7]}
+        self.setup_aldb(aldb, incomplete, ALDBStatus.LOADING)
+        assert aldb.status == ALDBStatus.PARTIAL
+
+        self.setup_aldb(aldb, {}, ALDBStatus.LOADING)
+        assert aldb.status == ALDBStatus.EMPTY
+
+        self.setup_aldb(aldb, {}, ALDBStatus.LOADED)
+        assert aldb.status == ALDBStatus.EMPTY
+
+    @async_case
     async def test_add(self):
         """Test the add method."""
         address = random_address()

--- a/tests/test_aldb/test_aldb_load.py
+++ b/tests/test_aldb/test_aldb_load.py
@@ -9,7 +9,7 @@ from pyinsteon.aldb.aldb import ALDB
 from pyinsteon.aldb.aldb_record import ALDBRecord
 from pyinsteon.constants import ALDBStatus
 
-from tests.utils import async_case
+from tests.utils import async_case, random_address
 
 
 def _record(mem_addr, high_water_mark=False):
@@ -76,6 +76,77 @@ class TestConcurrentLoads(unittest.TestCase):
         aldb, statuses = await self._run_overlapping(second_refresh=True)
         assert statuses == [ALDBStatus.LOADED, ALDBStatus.LOADED]
         assert aldb._read_manager.bulk_reads == 2
+
+
+class FailingReadManager:
+    """Serve only the first record, then answer nothing."""
+
+    def __init__(self):
+        """Init the FailingReadManager class."""
+        self.hit_erased = False
+
+    async def async_read(self, mem_addr=0x00, num_recs=0, read_write_mode=None):
+        """Yield the first record and nothing else."""
+        if num_recs == 1 and mem_addr in (0x00, 0x0FFF):
+            yield _record(0x0FFF)
+
+    async def async_stop(self):
+        """Stop the read."""
+
+
+class ShrunkenReadManager:
+    """Serve a database that is one record smaller than the cached one."""
+
+    def __init__(self):
+        """Init the ShrunkenReadManager class."""
+        self.hit_erased = False
+
+    async def async_read(self, mem_addr=0x00, num_recs=0, read_write_mode=None):
+        """Yield a complete two record database."""
+        if num_recs == 1 and mem_addr in (0x00, 0x0FFF):
+            yield _record(0x0FFF)
+        elif num_recs == 0:
+            yield _record(0x0FFF)
+            yield _record(0x0FF7, high_water_mark=True)
+
+    async def async_stop(self):
+        """Stop the read."""
+
+
+class TestRefreshRollback(unittest.TestCase):
+    """Test that a failed refresh does not destroy the cached records."""
+
+    def _loaded_aldb(self, read_manager):
+        aldb = ALDB(random_address())
+        previous = {
+            rec.mem_addr: rec
+            for rec in [
+                _record(0x0FFF),
+                _record(0x0FF7),
+                _record(0x0FEF, high_water_mark=True),
+            ]
+        }
+        aldb.load_saved_records(ALDBStatus.LOADED, previous)
+        aldb._read_manager = read_manager
+        return aldb
+
+    @async_case
+    async def test_failed_refresh_restores_the_previous_records(self):
+        """A refresh that dies partway leaves the last good record set."""
+        aldb = self._loaded_aldb(FailingReadManager())
+        status = await aldb.async_load(refresh=True)
+        assert status == ALDBStatus.LOADED
+        assert len(aldb) == 3
+        assert aldb[0x0FF7] is not None
+
+    @async_case
+    async def test_complete_refresh_replaces_the_previous_records(self):
+        """A refresh that reaches loaded keeps the fresh, smaller set."""
+        aldb = self._loaded_aldb(ShrunkenReadManager())
+        status = await aldb.async_load(refresh=True)
+        assert status == ALDBStatus.LOADED
+        assert len(aldb) == 2
+        assert aldb.get(0x0FEF) is None
 
 
 if __name__ == "__main__":

--- a/tests/test_aldb/test_modem_aldb.py
+++ b/tests/test_aldb/test_modem_aldb.py
@@ -161,6 +161,21 @@ class TestModemALDB(TestCase):
         assert len(aldb) == 4
 
     @async_case
+    async def test_incomplete_read_keeps_pending_changes(self):
+        """Test a re-read that dies partway keeps changes not yet written."""
+        aldb = _eeprom_aldb(MockEepromReader())
+        await aldb.async_load()
+        assert aldb.status == ALDBStatus.LOADED
+        aldb.add(group=1, target=random_address(), controller=True)
+        assert len(aldb.pending_changes) == 1
+
+        aldb._read_manager = MockEepromReader(fail_always=[0x1FF7])
+        await aldb.async_load(refresh=True)
+
+        assert aldb.status == ALDBStatus.LOADED
+        assert len(aldb.pending_changes) == 1
+
+    @async_case
     async def test_incomplete_read_keeps_an_equal_sized_saved_set(self):
         """Test a same size read with no high water mark keeps the saved records."""
         saved = {

--- a/tests/test_managers/test_aldb_im_write_manager.py
+++ b/tests/test_managers/test_aldb_im_write_manager.py
@@ -1,0 +1,107 @@
+"""Test the modem ALDB write manager."""
+
+# pylint: disable=protected-access
+import unittest
+
+from pyinsteon.aldb.aldb_record import ALDBRecord
+from pyinsteon.constants import (
+    ManageAllLinkRecordAction,
+    ReadWriteMode,
+    ResponseStatus,
+)
+from pyinsteon.managers.aldb_im_write_manager import ImWriteManager
+
+from tests.utils import async_case, random_address
+
+
+class _FakeModemALDB:
+    """Modem ALDB stand-in serving a fixed record list."""
+
+    def __init__(self, records):
+        """Init the _FakeModemALDB class."""
+        self._record_list = records
+        self.is_loaded = True
+        self.read_write_mode = ReadWriteMode.STANDARD
+
+    async def async_find_records(self, address, group):
+        """Yield records matching the address and group."""
+        for rec in self._record_list:
+            if rec.target == address and rec.group == group:
+                yield rec
+
+
+class _FakeWriteCmd:
+    """Capture the manage-all-link-record sends."""
+
+    def __init__(self):
+        """Init the _FakeWriteCmd class."""
+        self.calls = []
+
+    async def async_send(self, **kwargs):
+        """Record the call and report success."""
+        self.calls.append(kwargs)
+        return ResponseStatus.SUCCESS
+
+
+class TestImWriteManagerStandardDelete(unittest.TestCase):
+    """Test the standard-mode delete path."""
+
+    def _manager(self, modem_records):
+        mgr = ImWriteManager(_FakeModemALDB(modem_records))
+        mgr._write_cmd = _FakeWriteCmd()
+        return mgr
+
+    @async_case
+    async def test_delete_sends_the_matching_record(self):
+        """Deleting a record sends DELETE_FIRST for the record found."""
+        target = random_address()
+        existing = ALDBRecord(
+            0x1FFF,
+            controller=True,
+            group=1,
+            target=target,
+            data1=2,
+            data2=10,
+            data3=44,
+        )
+        deleted = ALDBRecord(
+            0x1FFF,
+            controller=True,
+            group=1,
+            target=target,
+            data1=2,
+            data2=10,
+            data3=44,
+            in_use=False,
+        )
+        mgr = self._manager([existing])
+        result = await mgr.async_write(deleted)
+        assert result == ResponseStatus.SUCCESS
+        assert len(mgr._write_cmd.calls) == 1
+        call = mgr._write_cmd.calls[0]
+        assert call["action"] == ManageAllLinkRecordAction.DELETE_FIRST
+        assert call["group"] == 1
+        assert call["target"] == target
+        assert call["controller"]
+
+    @async_case
+    async def test_delete_without_a_matching_record_fails(self):
+        """Deleting a record the modem does not hold sends nothing."""
+        deleted = ALDBRecord(
+            0x1FFF,
+            controller=True,
+            group=1,
+            target=random_address(),
+            data1=0,
+            data2=0,
+            data3=0,
+            in_use=False,
+        )
+        mgr = self._manager([])
+        result = await mgr.async_write(deleted)
+        assert result == ResponseStatus.FAILURE
+        assert not mgr._write_cmd.calls
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_managers/test_broken_links.py
+++ b/tests/test_managers/test_broken_links.py
@@ -1,0 +1,107 @@
+"""Test broken link detection across device databases."""
+
+import unittest
+
+from pyinsteon.aldb.aldb import ALDB
+from pyinsteon.aldb.aldb_record import ALDBRecord
+from pyinsteon.aldb.no_aldb import NoALDB
+from pyinsteon.constants import ALDBStatus, LinkStatus
+from pyinsteon.managers.link_manager import get_broken_links
+
+from tests.utils import async_case, random_address
+
+
+class _Device:
+    """Stand-in device wrapping an ALDB."""
+
+    def __init__(self, aldb):
+        """Init the _Device class."""
+        self.aldb = aldb
+        self.address = aldb.address
+
+
+def _loaded_aldb(address, record):
+    hwm = ALDBRecord(
+        0x0FF7,
+        controller=False,
+        group=0,
+        target="000000",
+        data1=0,
+        data2=0,
+        data3=0,
+        in_use=False,
+        high_water_mark=True,
+    )
+    aldb = ALDB(address)
+    aldb.load_saved_records(
+        ALDBStatus.LOADED, {0x0FFF: record, 0x0FF7: hwm}
+    )
+    return aldb
+
+
+def _controller_rec(target, group=1, in_use=True):
+    return ALDBRecord(
+        0x0FFF,
+        controller=True,
+        group=group,
+        target=target,
+        data1=3,
+        data2=0,
+        data3=group,
+        in_use=in_use,
+    )
+
+
+def _responder_rec(target, group=1, in_use=True):
+    return ALDBRecord(
+        0x0FFF,
+        controller=False,
+        group=group,
+        target=target,
+        data1=255,
+        data2=28,
+        data3=1,
+        in_use=in_use,
+    )
+
+
+class TestBrokenLinks(unittest.TestCase):
+    """Test get_broken_links against target database states."""
+
+    @async_case
+    async def test_link_to_no_aldb_device_is_not_broken(self):
+        """A link to a device with no ALDB is not reported as broken."""
+        addr_a = random_address()
+        addr_b = random_address()
+        dev_a = _Device(_loaded_aldb(addr_a, _controller_rec(addr_b)))
+        dev_b = _Device(NoALDB(addr_b))
+        broken = get_broken_links({addr_a: dev_a, addr_b: dev_b})
+        assert broken == []
+
+    @async_case
+    async def test_deleted_target_record_does_not_satisfy_the_link(self):
+        """A not-in-use record on the target does not complete the pair."""
+        addr_a = random_address()
+        addr_b = random_address()
+        dev_a = _Device(_loaded_aldb(addr_a, _controller_rec(addr_b)))
+        dev_b = _Device(_loaded_aldb(addr_b, _responder_rec(addr_a, in_use=False)))
+        broken = get_broken_links({addr_a: dev_a, addr_b: dev_b})
+        assert len(broken) == 1
+        address, record, status = broken[0]
+        assert address == addr_a
+        assert record.mem_addr == 0x0FFF
+        assert status == LinkStatus.MISSING_RESPONDER
+
+    @async_case
+    async def test_matching_in_use_records_are_not_broken(self):
+        """A complete controller and responder pair reports nothing."""
+        addr_a = random_address()
+        addr_b = random_address()
+        dev_a = _Device(_loaded_aldb(addr_a, _controller_rec(addr_b)))
+        dev_b = _Device(_loaded_aldb(addr_b, _responder_rec(addr_a)))
+        broken = get_broken_links({addr_a: dev_a, addr_b: dev_b})
+        assert broken == []
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_managers/test_saved_devices_manager.py
+++ b/tests/test_managers/test_saved_devices_manager.py
@@ -1,0 +1,101 @@
+"""Test saving and restoring devices from the device cache file."""
+
+import json
+import os
+import tempfile
+import unittest
+
+from pyinsteon.aldb.aldb_record import ALDBRecord
+from pyinsteon.constants import ALDBStatus, EngineVersion
+from pyinsteon.managers.device_id_manager import DeviceId
+from pyinsteon.managers.saved_devices_manager import (
+    DEVICE_INFO_FILE,
+    SavedDeviceManager,
+)
+from pyinsteon.managers.utils import create_device
+
+from tests.utils import async_case, random_address
+
+
+class _Modem:
+    """Stand-in modem carrying only an address."""
+
+    def __init__(self):
+        """Init the _Modem class."""
+        self.address = random_address()
+
+
+def _records(target):
+    recs = [
+        ALDBRecord(
+            0x0FFF,
+            controller=True,
+            group=1,
+            target=target,
+            data1=0,
+            data2=0,
+            data3=0,
+        ),
+        ALDBRecord(
+            0x0FF7,
+            controller=False,
+            group=0,
+            target="000000",
+            data1=0,
+            data2=0,
+            data3=0,
+            in_use=False,
+            high_water_mark=True,
+        ),
+    ]
+    return {rec.mem_addr: rec for rec in recs}
+
+
+class TestSavedDevicesManager(unittest.TestCase):
+    """Test the SavedDeviceManager file handling."""
+
+    @async_case
+    async def test_save_and_load_round_trip(self):
+        """A saved device list is written atomically and loads back."""
+        address = random_address()
+        device = create_device(DeviceId(address, 0x02, 0x0A, 0x44))
+        device.engine_version = EngineVersion.I2
+        device.aldb.load_saved_records(ALDBStatus.LOADED, _records(random_address()))
+        with tempfile.TemporaryDirectory() as workdir:
+            mgr = SavedDeviceManager(workdir, _Modem())
+            await mgr.async_save({address: device})
+
+            device_file = os.path.join(workdir, DEVICE_INFO_FILE)
+            assert os.path.exists(device_file)
+            assert not os.path.exists(f"{device_file}.tmp")
+            with open(device_file, encoding="utf-8") as afp:
+                saved = json.load(afp)
+            assert len(saved) == 1
+            assert saved[0]["address"] == address.id
+            assert saved[0]["aldb_status"] == ALDBStatus.LOADED.value
+
+            loaded = await SavedDeviceManager(workdir, _Modem()).async_load()
+            assert len(loaded) == 1
+            assert loaded[address].aldb.status == ALDBStatus.LOADED
+            assert len(loaded[address].aldb) == 2
+
+    @async_case
+    async def test_corrupt_device_file_is_kept_aside(self):
+        """A corrupt device file is moved aside and logged as an error."""
+        with tempfile.TemporaryDirectory() as workdir:
+            device_file = os.path.join(workdir, DEVICE_INFO_FILE)
+            with open(device_file, "w", encoding="utf-8") as afp:
+                afp.write('{"unterminated": ')
+            mgr = SavedDeviceManager(workdir, _Modem())
+            with self.assertLogs(
+                "pyinsteon.managers.saved_devices_manager", level="ERROR"
+            ):
+                loaded = await mgr.async_load()
+            assert loaded == {}
+            assert not os.path.exists(device_file)
+            with open(f"{device_file}.corrupt", encoding="utf-8") as afp:
+                assert afp.read() == '{"unterminated": '
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_managers/test_saved_devices_manager.py
+++ b/tests/test_managers/test_saved_devices_manager.py
@@ -1,5 +1,6 @@
 """Test saving and restoring devices from the device cache file."""
 
+# pylint: disable=protected-access
 import json
 import os
 import tempfile
@@ -78,6 +79,23 @@ class TestSavedDevicesManager(unittest.TestCase):
             assert len(loaded) == 1
             assert loaded[address].aldb.status == ALDBStatus.LOADED
             assert len(loaded[address].aldb) == 2
+
+    @async_case
+    async def test_loading_status_is_saved_as_partial(self):
+        """A device caught mid-read is saved as partial, not loading."""
+        address = random_address()
+        device = create_device(DeviceId(address, 0x02, 0x0A, 0x44))
+        device.engine_version = EngineVersion.I2
+        device.aldb.load_saved_records(ALDBStatus.LOADED, _records(random_address()))
+        device.aldb._update_status(ALDBStatus.LOADING)
+        with tempfile.TemporaryDirectory() as workdir:
+            mgr = SavedDeviceManager(workdir, _Modem())
+            await mgr.async_save({address: device})
+            with open(
+                os.path.join(workdir, DEVICE_INFO_FILE), encoding="utf-8"
+            ) as afp:
+                saved = json.load(afp)
+            assert saved[0]["aldb_status"] == ALDBStatus.PARTIAL.value
 
     @async_case
     async def test_corrupt_device_file_is_kept_aside(self):


### PR DESCRIPTION
Six fixes to the device cache and the link database read path.

- `insteon_devices.json` writes to a temp file and renames, under a lock, with fsync. It was truncate in place from eight unsynchronised call sites. A corrupt file moves to `.corrupt` and logs an error instead of returning an empty device list at debug
- a refresh that does not reach LOADED restores the records it cleared. `ALDB._async_load` clears before the first read, so an interrupted refresh replaces a good set with a partial one and saves it
- LOADING is not persisted. It was replayed verbatim on restart, so a failed read stayed failed and the startup config task re-walked the device every boot
- `get_broken_links` skips `NoALDB` devices and ignores deleted target records. A Range Extender holds no database, so every modem link to one reported broken with no action that could clear it
- `_async_write_delete_standard` iterates the async generator, passes `(action, record)` in signature order, awaits the write, and returns FAILURE when nothing matches. It has raised TypeError on its first statement since 2022. Fixes #439
- `ModemALDB.async_load` keeps pending changes when a re-read dies partway and the saved records are restored. `load_saved_records` clears them, so a write queued during that read was dropped without a trace

564 tests on 3.14. pylint, flake8 and black clean on 3.11 with the pinned versions.
