### PR TITLE
Keep a device's identity when a link complete reports none

### DIFF
--- a/pyinsteon/managers/device_id_manager.py
+++ b/pyinsteon/managers/device_id_manager.py
@@ -9,7 +9,7 @@ import async_timeout
 
 from .. import pub
 from ..address import Address
-from ..constants import DeviceAction, ResponseStatus
+from ..constants import AllLinkMode, DeviceAction, ResponseStatus
 from ..handlers.all_link_completed import AllLinkCompletedHandler
 from ..handlers.from_device.assign_to_all_link_group import AssignToAllLinkGroupCommand
 from ..handlers.from_device.delete_from_all_link_group import (
@@ -203,6 +203,15 @@ class DeviceIdManager(SubscriberBase):
 
     def _id_response(self, address, cat, subcat, firmware, group, link_mode):
         """Receive a device ID response."""
+        known = self._device_ids.get(Address(address))
+        if not cat and not subcat and known is not None and known.cat is not None:
+            _LOGGER.debug(
+                "Device %s reported no identity, keeping %s.%s",
+                address,
+                known.cat,
+                known.subcat,
+            )
+            cat, subcat, firmware = known.cat, known.subcat, known.firmware
         self.set_device_id(
             address=address,
             cat=cat,
@@ -259,6 +268,17 @@ class DeviceIdManager(SubscriberBase):
         self, link_mode, group, target, cat, subcat, firmware
     ):
         """Receive All-Link complete message."""
+        if link_mode == AllLinkMode.RESPONDER:
+            # Dev Guide 0x53: DevCat and SubCat are only valid when the IM is the controller
+            address = Address(target)
+            known = self._device_ids.get(address)
+            if known is None or known.cat is None:
+                self.append(address)
+                self._call_subscribers(
+                    device_id=DeviceId(address, None, None, None), link_mode=link_mode
+                )
+                return
+            cat, subcat, firmware = known.cat, known.subcat, known.firmware
         self._id_response(target, cat, subcat, firmware, group, link_mode)
 
     async def _ping_device(self, address):

--- a/tests/test_managers/test_device_id_manager.py
+++ b/tests/test_managers/test_device_id_manager.py
@@ -4,6 +4,7 @@ import asyncio
 import unittest
 
 from pyinsteon.address import Address
+from pyinsteon.constants import AllLinkMode
 from pyinsteon.managers.device_id_manager import DeviceIdManager
 from pyinsteon.topics import ASSIGN_TO_ALL_LINK_GROUP, ID_REQUEST, OFF
 from tests.utils import TopicItem, async_case, cmd_kwargs, send_topics
@@ -15,6 +16,7 @@ class TestDeviceIdManager(unittest.TestCase):
     def setUp(self):
         """Set up the test."""
         self._test_response = None
+        self._received = []
         self._modem_address = Address("4d5e6f")
         self._cat = 0x01
         self._subcat = 0x02
@@ -76,6 +78,93 @@ class TestDeviceIdManager(unittest.TestCase):
         assert self._id_mgr[address].cat == self._cat
         assert self._id_mgr[address].subcat == self._subcat
         assert self._id_mgr[address].firmware == self._firmware
+
+    def _record_id(self, device_id, link_mode):
+        self._received.append(device_id)
+
+    @async_case
+    async def test_link_complete_without_identity_keeps_known_device(self):
+        """Test a link complete carrying no identity keeps the known one."""
+        self._id_mgr = DeviceIdManager()
+        address = Address("050505")
+        self._id_mgr.set_device_id(address, self._cat, self._subcat, self._firmware)
+        self._id_mgr.subscribe(self._record_id)
+
+        # pylint: disable=protected-access
+        self._id_mgr._all_link_complete_received(
+            link_mode=AllLinkMode.RESPONDER,
+            group=0,
+            target=address,
+            cat=0,
+            subcat=0,
+            firmware=0,
+        )
+        assert self._id_mgr[address].cat == self._cat
+        assert self._id_mgr[address].subcat == self._subcat
+        assert self._id_mgr[address].firmware == self._firmware
+        assert self._received[-1].cat == self._cat
+
+    @async_case
+    async def test_link_complete_as_responder_keeps_known_device(self):
+        """Test the identity bytes are ignored when the modem is the responder."""
+        self._id_mgr = DeviceIdManager()
+        address = Address("070707")
+        self._id_mgr.set_device_id(address, self._cat, self._subcat, self._firmware)
+        self._id_mgr.subscribe(self._record_id)
+
+        # pylint: disable=protected-access
+        self._id_mgr._all_link_complete_received(
+            link_mode=AllLinkMode.RESPONDER,
+            group=1,
+            target=address,
+            cat=0x10,
+            subcat=0x20,
+            firmware=0x30,
+        )
+        assert self._id_mgr[address].cat == self._cat
+        assert self._id_mgr[address].subcat == self._subcat
+        assert self._received[-1].cat == self._cat
+
+    @async_case
+    async def test_link_complete_as_responder_leaves_new_device_unknown(self):
+        """Test a new device linked as controller waits for an ID request."""
+        self._id_mgr = DeviceIdManager()
+        address = Address("060606")
+        self._id_mgr.subscribe(self._record_id)
+
+        # pylint: disable=protected-access
+        self._id_mgr._all_link_complete_received(
+            link_mode=AllLinkMode.RESPONDER,
+            group=1,
+            target=address,
+            cat=0,
+            subcat=0,
+            firmware=0,
+        )
+        assert self._id_mgr[address].cat is None
+        assert address in self._id_mgr.unknown_devices
+        assert self._received[-1].address == address
+        assert self._received[-1].cat is None
+        self._id_mgr.close()
+        await asyncio.sleep(0.1)
+
+    @async_case
+    async def test_link_complete_as_controller_sets_identity(self):
+        """Test the identity bytes are used when the modem is the controller."""
+        self._id_mgr = DeviceIdManager()
+        address = Address("080808")
+
+        # pylint: disable=protected-access
+        self._id_mgr._all_link_complete_received(
+            link_mode=AllLinkMode.CONTROLLER,
+            group=0,
+            target=address,
+            cat=self._cat,
+            subcat=self._subcat,
+            firmware=self._firmware,
+        )
+        assert self._id_mgr[address].cat == self._cat
+        assert self._id_mgr[address].subcat == self._subcat
 
     @async_case
     async def test_id_device(self):


### PR DESCRIPTION
The modem's ALL-Linking Completed message (0x53) carries the linked device's DevCat, SubCat and firmware, but the INSTEON Developer's Guide (Feb 2009, p. 247) marks DevCat and SubCat as "only valid when the IM is a Controller". When the device starts the link (set button held on a switch, link code 0x00, IM is the responder) the PLM reports 00/00/00. `DeviceIdManager` passed those bytes to `set_device_id` anyway, so `DeviceManager` replaced two known 2476S relays with Generic General Controllers, the saved cache lost their identity, and the default-links step wrote 00/00/00 into the modem's records for them. Seen on an i1 and an i2 relay re-paired across an RF island; the same session's controller-side link of a 2477S came through with correct bytes.

`_all_link_complete_received` now ignores the identity bytes when the modem is the responder: a known device keeps its identity, a new one is registered as unknown and identified through the usual ID request path. Independently, a response carrying 00/00 for a known device is ignored whatever the link mode. Controller-side link completes are handled as before.

Tests: known device kept (zeros, and non-zero garbage as responder), new device left unknown as responder, identity applied as controller. Full suite run locally.
