### PR TITLE
Wait for a load in progress before writing the ALDB

### DIFF
--- a/pyinsteon/aldb/aldb.py
+++ b/pyinsteon/aldb/aldb.py
@@ -32,7 +32,6 @@ class ALDB(ALDBBase):
         super().__init__(address=address, version=version, mem_addr=mem_addr)
         self._top_mem_addr = mem_addr
         self._read_manager = ALDBReadManager(self._address, self._mem_addr)
-        self._load_lock = asyncio.Lock()
 
     # pylint: disable=arguments-differ
     async def async_load(

--- a/pyinsteon/aldb/aldb_base.py
+++ b/pyinsteon/aldb/aldb_base.py
@@ -1,6 +1,7 @@
 """Base class for the All-Link Database."""
 
 from abc import ABC, abstractmethod
+import asyncio
 import logging
 from typing import List, Tuple
 
@@ -48,6 +49,7 @@ class ALDBBase(ABC):
         self._read_manager = None
         self._write_manager = write_manager(self)
         self._dirty_records = {}
+        self._load_lock = asyncio.Lock()
         subscribe_topic(self.update_version, f"{repr(self._address)}.{ENGINE_VERSION}")
 
     def __len__(self):
@@ -287,6 +289,9 @@ class ALDBBase(ABC):
 
     async def async_write(self, force=False) -> Tuple[int, int]:
         """Write the dirty records to the device."""
+        if self._status == ALDBStatus.LOADING:
+            async with self._load_lock:
+                pass
         if not self.is_loaded and not force:
             _LOGGER.warning(
                 "ALDB of %s must be loaded before it can be written Status: %s",

--- a/pyinsteon/aldb/modem_aldb.py
+++ b/pyinsteon/aldb/modem_aldb.py
@@ -1,6 +1,5 @@
 """All-Link database for an Insteon Modem."""
 
-import asyncio
 import logging
 
 from .. import pub
@@ -31,7 +30,6 @@ class ModemALDB(ALDBBase):
         super().__init__(address, version, mem_addr, write_manager=ImWriteManager)
 
         self._read_write_mode = ReadWriteMode.UNKNOWN
-        self._load_lock = asyncio.Lock()
         # If we are not the first modem, don't subscribe to
         mgr = pub.getDefaultTopicMgr()
         topic = mgr.getTopic(ALL_LINK_RECORD_RESPONSE, okIfNone=True)

--- a/tests/test_aldb/test_modem_aldb.py
+++ b/tests/test_aldb/test_modem_aldb.py
@@ -7,7 +7,7 @@ from pyinsteon import pub
 from pyinsteon.address import Address
 from pyinsteon.aldb import modem_aldb
 from pyinsteon.aldb.aldb_record import ALDBRecord
-from pyinsteon.constants import ALDBStatus, ReadWriteMode
+from pyinsteon.constants import ALDBStatus, ReadWriteMode, ResponseStatus
 from pyinsteon.topics import ALL_LINK_RECORD_RESPONSE
 
 from pyinsteon.aldb.modem_aldb import ModemALDB
@@ -64,6 +64,19 @@ class GatedEepromReader(MockEepromReader):
         """Return the record at mem_addr once released."""
         await self.release.wait()
         return await super().async_read_record(mem_addr)
+
+
+class RecordingWriter:
+    """Accept every write and remember it."""
+
+    def __init__(self):
+        """Init the RecordingWriter class."""
+        self.writes = []
+
+    async def async_write(self, record, force=False):
+        """Record the write and report success."""
+        self.writes.append(record)
+        return ResponseStatus.SUCCESS
 
 
 # pypubsub holds weak references to the subscribed handlers
@@ -200,3 +213,26 @@ class TestModemALDB(TestCase):
 
         assert aldb.status == ALDBStatus.LOADED
         assert reader.reads == [0x1FFF, 0x1FF7, 0x1FEF, 0x1FE7]
+
+    @async_case
+    async def test_write_waits_for_a_load_in_progress(self):
+        """Test a write issued during a load runs once the load is done."""
+        reader = GatedEepromReader()
+        aldb = _eeprom_aldb(reader)
+        writer = RecordingWriter()
+        aldb._write_manager = writer
+
+        load = asyncio.ensure_future(aldb.async_load())
+        await asyncio.sleep(0.01)
+        assert aldb.status == ALDBStatus.LOADING
+
+        aldb.add(group=1, target=random_address(), controller=True)
+        write = asyncio.ensure_future(aldb.async_write())
+        await asyncio.sleep(0.01)
+        assert not writer.writes
+
+        reader.release.set()
+        await load
+        assert await write == (1, 0)
+        assert writer.writes[0].mem_addr == 0x1FE7
+        assert not aldb.pending_changes


### PR DESCRIPTION
`ALDBBase.async_write` refuses immediately when the ALDB status is LOADING and leaves the records in `_dirty_records`. After linking a new device, `DeviceManager.async_inspect_device` re-reads the whole modem ALDB (about 90 s on a 136-record PLM), so any write that lands in that window is dropped without the caller knowing. Observed with a device removal issued 34 s after a link: the modem deletes were only written a minute later, as a side effect of the next unrelated write.

The load lock now lives in `ALDBBase`, and `async_write` waits for a load in progress to finish before applying the existing loaded check. Behaviour when no load is running is unchanged.

Tests: a modem write issued mid-load completes once the read finishes. Full suite run locally.
